### PR TITLE
Add Dockerfile for container deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.venv
+__pycache__
+*.pyc
+.env.private
+docs/
+.opencode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install dependencies first (better layer caching)
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY soundcork/ soundcork/
+
+# The app imports "from soundcork.bmx import ..." so /app must be on PYTHONPATH
+# The app reads bmx_services.json, swupdate.xml, and media/ from CWD
+ENV PYTHONPATH=/app
+WORKDIR /app/soundcork
+
+# Gunicorn with uvicorn workers, bind to all interfaces
+# Override log files to stdout/stderr for container logging
+CMD ["gunicorn", "-c", "gunicorn_conf.py", "--bind", "0.0.0.0:8000", \
+     "--access-logfile", "-", "--error-logfile", "-", \
+     "--workers", "2", \
+     "main:app"]


### PR DESCRIPTION
## Summary

Adds a Dockerfile and `.dockerignore` for running soundcork in a container.

Closes #170

## Details

- **Base image:** `python:3.12-slim`
- **Server:** Gunicorn with 2 uvicorn workers
- **Logging:** Overridden to stdout/stderr for container log capture
- **Architecture:** Works with multi-arch builds (amd64 + arm64, tested on Raspberry Pi)

### Key decisions

- `ENV PYTHONPATH=/app` is required for soundcork imports to resolve
- `WORKDIR /app/soundcork` because `bmx_services.json`, `swupdate.xml`, and `media/` are read relative to CWD
- Binds to `0.0.0.0:8000` (overrides `gunicorn_conf.py` default of `127.0.0.1`)

### Usage

```bash
docker build -t soundcork .
docker run -d -p 8000:8000 \
  -v ./data:/soundcork/data \
  -e base_url=http://your-server:8000 \
  -e data_dir=/soundcork/data \
  soundcork
```

Tested with a SoundTouch 20 on firmware 27.0.6.