### PR TITLE
Add sanitized example data files

### DIFF
--- a/examples/DeviceInfo.xml
+++ b/examples/DeviceInfo.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<info deviceID="YOUR_DEVICE_ID">
+    <name>Your-Speaker-Name</name>
+    <type>SoundTouch 20</type>
+    <margeAccountUUID>YOUR_ACCOUNT_ID</margeAccountUUID>
+    <components>
+        <component>
+            <componentCategory>SCM</componentCategory>
+            <softwareVersion>27.0.6.46330.5043500 epdbuild.trunk.hepdswbld04.2022-08-04T11:20:29</softwareVersion>
+            <serialNumber>XXXXXXXXXXX</serialNumber>
+        </component>
+        <component>
+            <componentCategory>PackagedProduct</componentCategory>
+            <serialNumber>XXXXXXXXXXX</serialNumber>
+        </component>
+        <component>
+            <componentCategory>Lightswitch</componentCategory>
+            <serialNumber></serialNumber>
+        </component>
+        <component>
+            <componentCategory>SMSC</componentCategory>
+            <softwareVersion>I2014102015199423; B201306111041 081008C 2014102015199423</softwareVersion>
+            <serialNumber>XXXXXXXXXXX</serialNumber>
+        </component>
+    </components>
+    <margeURL>https://your-soundcork-server/marge</margeURL>
+    <networkInfo type="SCM">
+        <macAddress>000000000000</macAddress>
+        <ipAddress>192.168.1.x</ipAddress>
+    </networkInfo>
+    <networkInfo type="SMSC">
+        <macAddress>000000000000</macAddress>
+        <ipAddress>192.168.1.x</ipAddress>
+    </networkInfo>
+    <moduleType>scm</moduleType>
+    <variant>spotty</variant>
+    <variantMode>normal</variantMode>
+    <countryCode>EU</countryCode>
+    <regionCode></regionCode>
+</info>

--- a/examples/Presets.xml
+++ b/examples/Presets.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<presets>
+    <preset id="1" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s102123" sourceAccount="" isPresetable="true">
+            <itemName>Joe</itemName>
+            <containerArt>http://cdn-profiles.tunein.com/s25741/images/logoq.png</containerArt>
+        </ContentItem>
+    </preset>
+    <preset id="2" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s69243" sourceAccount="" isPresetable="true">
+            <itemName>QMusic Belgium</itemName>
+        </ContentItem>
+    </preset>
+    <preset id="3" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s214611" sourceAccount="" isPresetable="true">
+            <itemName>RGR Dance</itemName>
+            <containerArt>http://cdn-profiles.tunein.com/s214611/images/logog.jpg?t=638199227250000000</containerArt>
+        </ContentItem>
+    </preset>
+    <preset id="4" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s10861" sourceAccount="" isPresetable="true">
+            <itemName>VRT MNM</itemName>
+            <containerArt>http://cdn-profiles.tunein.com/s10861/images/logoq.png</containerArt>
+        </ContentItem>
+    </preset>
+    <preset id="5" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s2611" sourceAccount="" isPresetable="true">
+            <itemName>VRT Studio Brussel</itemName>
+        </ContentItem>
+    </preset>
+    <preset id="6" createdOn="1695000000" updatedOn="1695000000">
+        <ContentItem source="SPOTIFY" type="tracklisturl" location="YOUR_BASE64_ENCODED_SPOTIFY_URI" sourceAccount="YOUR_SPOTIFY_ACCOUNT_ID" isPresetable="true">
+            <itemName>Your Artist Name</itemName>
+            <containerArt>https://i.scdn.co/image/YOUR_ALBUM_ART_HASH</containerArt>
+        </ContentItem>
+    </preset>
+</presets>

--- a/examples/Recents.xml
+++ b/examples/Recents.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<recents>
+    <recent deviceID="YOUR_DEVICE_ID" utcTime="1771287920" id="2454152503">
+        <contentItem source="SPOTIFY" type="tracklisturl" location="/playback/container/YOUR_BASE64_ENCODED_URI" sourceAccount="YOUR_SPOTIFY_ACCOUNT_ID" isPresetable="true">
+            <itemName>Artist Name</itemName>
+        </contentItem>
+    </recent>
+    <recent deviceID="YOUR_DEVICE_ID" utcTime="1771286998" id="2307122547">
+        <contentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s69243" sourceAccount="" isPresetable="true">
+            <itemName>QMusic Belgium</itemName>
+        </contentItem>
+    </recent>
+</recents>

--- a/examples/Sources.xml
+++ b/examples/Sources.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<sources>
+    <source displayName="AUX IN" secret="" secretType="">
+        <sourceKey type="AUX" account="AUX" />
+    </source>
+    <source secret="" secretType="token">
+        <sourceKey type="INTERNET_RADIO" account="" />
+    </source>
+    <source secret="REDACTED_BASE64_TOKEN" secretType="token">
+        <sourceKey type="LOCAL_INTERNET_RADIO" account="" />
+    </source>
+    <source displayName="your@email.com" secret="REDACTED_SPOTIFY_OAUTH_TOKEN" secretType="token_version_3">
+        <sourceKey type="SPOTIFY" account="YOUR_SPOTIFY_ACCOUNT_ID" />
+    </source>
+    <source secret="REDACTED_BASE64_TOKEN" secretType="token">
+        <sourceKey type="TUNEIN" account="" />
+    </source>
+</sources>


### PR DESCRIPTION
## Summary

Adds example XML files showing the exact format that soundcork's datastore expects. Based on a real SoundTouch 20 deployment with all sensitive data redacted.

Closes #171

## Files

| File | Contents | What's redacted |
|------|----------|----------------|
| `examples/Presets.xml` | 5 TuneIn presets + 1 Spotify | Spotify account → placeholder |
| `examples/Sources.xml` | AUX, INTERNET_RADIO, LOCAL_INTERNET_RADIO, SPOTIFY, TUNEIN | All OAuth tokens → `REDACTED` |
| `examples/Recents.xml` | 2 recent entries (1 TuneIn, 1 Spotify) | Device IDs, Spotify account → placeholder |
| `examples/DeviceInfo.xml` | SoundTouch 20 device structure | Serial numbers, IPs, MACs, account ID → placeholder |

TuneIn station IDs are kept as-is (they're public — e.g., `s102123` = Joe, `s69243` = QMusic Belgium).

## Why

New users can reference these to verify their extracted XML files match the expected format. The data directory structure (`data/<accountId>/...`) is documented in the README but seeing the actual XML structure helps.