### PR TITLE
Add deployment guide (Docker, Compose, Kubernetes, bare metal)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -208,15 +208,6 @@ sudo systemctl enable --now soundcork
 
 > **Note:** Make sure `PYTHONPATH` includes the project root and that the working directory is set correctly in your service file or shell environment.
 
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `base_url` | `""` | Public URL of your SoundCork instance (e.g., `https://soundcork.example.com`) |
-| `data_dir` | `""` | Path to the speaker data directory |
-| `SOUNDCORK_MODE` | `local` | `local` (recommended) or `proxy` — see [Architecture](architecture.md) |
-| `SOUNDCORK_LOG_DIR` | `./logs/traffic` | Directory for traffic logs (proxy mode only) |
-
 ## Container Image
 
 - **Image:** `ghcr.io/deborahgu/soundcork:main`


### PR DESCRIPTION
## Summary

Adds a comprehensive deployment guide covering multiple options.

Closes #175

## Content

### Option 1: Docker
Single `docker run` command with all required env vars and volume mounts.

### Option 2: Docker Compose
Full `docker-compose.yml` with environment variables, volumes, and restart policy.

### Option 3: Kubernetes
Example manifests (namespace, deployment, service, standard Kubernetes Ingress with cert-manager TLS). Uses placeholder values that users customize for their environment.

### Option 4: Bare Metal
Python 3.12 venv setup, development server, production gunicorn, systemd reference.

### Also includes
- Environment variables table (`base_url`, `data_dir`, `SOUNDCORK_MODE`, `SOUNDCORK_LOG_DIR`)
- Container image details (multi-arch amd64+arm64)
- Verification steps

Note: The Docker options reference a container image. If the Dockerfile PR (#176) is merged, this guide works out of the box with a locally built image. For a published image, a CI workflow would need to be set up.