### PR TITLE
Add Spotify support with OAuth intercept and ZeroConf primer

### DIFF
--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -1,0 +1,129 @@
+# Spotify on SoundTouch
+
+## Two Different Spotify Systems
+
+There are two completely separate ways Spotify works on a SoundTouch speaker. This is a common source of confusion.
+
+### 1. Spotify Connect (Always Works)
+
+- The speaker advertises itself as a Spotify Connect device on your local network
+- Open the Spotify app on your phone or computer, tap the speaker/device icon, and select your SoundTouch speaker
+- Audio streams directly from Spotify's CDN to the speaker
+- **No Bose servers involved** — purely between the Spotify app, Spotify's servers, and the speaker
+- **No soundcork involvement** — Spotify Connect operates independently
+
+### 2. SoundTouch Spotify Integration (Presets)
+
+- This is what the SoundTouch app used for setting Spotify presets (buttons 1-6)
+- Originally relied on Bose's OAuth token management via the marge server
+- After the Bose shutdown, this path is broken **unless soundcork handles the token refresh**
+
+## Automatic Spotify Support
+
+Soundcork can keep Spotify presets working automatically. There are two mechanisms that serve different purposes, and both run together:
+
+### ZeroConf Primer (Cold Boot Activation)
+
+On cold boot, the speaker does **not** request a Spotify token — it only fetches account data, source providers, and streaming tokens. Without an active Spotify session, presets fail silently.
+
+The ZeroConf primer solves this by proactively pushing a fresh Spotify access token to the speaker via the ZeroConf endpoint (port 8200). This is the same mechanism the Spotify desktop app uses when you cast to a speaker.
+
+**When it runs:**
+- On speaker boot (`power_on` event), with retry/backoff (5s, 10s, 20s delays)
+- Periodically every 45 minutes (tokens expire after 1 hour)
+- When a new speaker is first seen via marge requests
+
+**Boot sequence observed:**
+```
+power_on → bmx/services → media icons → sourceproviders → /full → streaming_token → provider_settings
+```
+No OAuth token request happens during boot — the ZeroConf primer is what activates Spotify.
+
+### OAuth Token Intercept (Ongoing Refresh)
+
+Once the speaker has an active Spotify session (from the ZeroConf primer or a previous Spotify Connect cast), it will periodically refresh its token by calling an OAuth endpoint. Soundcork intercepts these requests and returns a valid token.
+
+**How it works:**
+1. Speaker sends `POST /oauth/device/{deviceId}/music/musicprovider/15/token/cs3`
+2. Soundcork refreshes the token using the stored Spotify account credentials
+3. Returns a fresh access token as JSON
+4. The speaker uses this token for continued Spotify playback
+
+This is transparent — the speaker manages its own refresh cycle, just like it did with `streamingoauth.bose.com`. No extra DNS configuration needed — the speaker already sends these requests to the same server as marge.
+
+## Setup
+
+### Step 1: Register a Spotify App
+
+1. Go to the [Spotify Developer Dashboard](https://developer.spotify.com/dashboard)
+2. Create a new app
+   - **Redirect URI**: `{your-soundcork-url}/mgmt/spotify/callback` (e.g., `https://soundcork.local:8000/mgmt/spotify/callback`)
+   - **APIs used**: Web API
+3. Note the **Client ID** and **Client Secret**
+
+### Step 2: Configure Soundcork
+
+Set the environment variables:
+
+```bash
+SPOTIFY_CLIENT_ID=your-client-id
+SPOTIFY_CLIENT_SECRET=your-client-secret
+```
+
+### Step 3: Link Your Spotify Account
+
+Using the management API:
+
+```bash
+# Start the OAuth flow
+curl -u admin:password https://your-soundcork/mgmt/spotify/auth/init
+
+# Open the returned URL in your browser, authorize, then complete:
+curl -u admin:password "https://your-soundcork/mgmt/spotify/auth/callback?code=AUTH_CODE"
+
+# Verify the account is linked
+curl -u admin:password https://your-soundcork/mgmt/spotify/accounts
+```
+
+Or use the [companion app](https://github.com/timvw/ueberboese-app) which handles this flow automatically.
+
+### Step 4: Verify
+
+After linking your Spotify account:
+- The OAuth intercept works immediately — the speaker will get fresh tokens on its next refresh cycle
+- The ZeroConf primer (if enabled) will prime the speaker within a few minutes
+- Press a Spotify preset button on the speaker — it should play
+
+## Technical Details
+
+### Token Lifecycle
+
+- Spotify access tokens expire after **1 hour** (3600 seconds)
+- The speaker's firmware requests a new token via the OAuth endpoint before expiry
+- The ZeroConf primer re-primes every **45 minutes** as an additional safety net
+- Soundcork caches tokens to avoid unnecessary Spotify API calls
+
+### What `cs3` / `token_version_3` Means
+
+The speaker requests tokens with `tokenType=cs3` in the URL. This corresponds to `token_version_3` in the XML credential format — it's Bose's internal versioning for their OAuth credential schema. The actual value is a standard Spotify access token.
+
+### Speaker ZeroConf Endpoint
+
+Each speaker exposes a ZeroConf endpoint on port 8200:
+- `GET /zc?action=getInfo` — returns speaker info including `activeUser`, `libraryVersion`
+- `POST /zc` with `action=addUser` — sets the active Spotify user
+
+### Alternative Approach: Manual Kick-Start
+
+If you don't want to configure Spotify credentials in soundcork, you can manually prime the speaker by casting one song via the Spotify app (Spotify Connect). This gives the speaker a temporary in-memory session that enables presets. However, you'll need to repeat this after every speaker reboot.
+
+## Managing Presets
+
+The official SoundTouch app can no longer configure presets pointing to TuneIn stations. Use the [Bose CLI](https://github.com/timvw/bose) to manage presets directly via the speaker's local API (port 8090):
+
+```bash
+brew install timvw/tap/bose
+bose preset       # view presets
+bose preset 1     # get a specific preset
+bose status       # speaker status
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ black==25.9.0
 fastapi[standard]==0.120.1
 fastapi-etag==0.4.0
 gunicorn==23.0.0
+httpx==0.28.1
 pydantic-settings==2.11.0
 telnetlib3==2.0.8
 upnpclient==1.0.3

--- a/soundcork/config.py
+++ b/soundcork/config.py
@@ -20,6 +20,16 @@ class Settings(BaseSettings):
 
     base_url: str = ""
     data_dir: str = ""
+
+    # Management API authentication
+    mgmt_username: str = "admin"
+    mgmt_password: str = "change_me!"
+
+    # Spotify OAuth (optional — leave empty to disable)
+    spotify_client_id: str = ""
+    spotify_client_secret: str = ""
+    spotify_redirect_uri: str = ""
+
     model_config = SettingsConfigDict(
         # `.env.private` takes priority over `.env.shared`
         env_file=(".env.shared", ".env.private")

--- a/soundcork/mgmt.py
+++ b/soundcork/mgmt.py
@@ -1,0 +1,241 @@
+"""Management API endpoints for soundcork.
+
+These endpoints are NOT part of the Bose SoundTouch protocol. They
+provide a JSON API for managing soundcork configuration, listing
+speakers, and optionally linking Spotify accounts.
+
+All endpoints require HTTP Basic Auth (configured via MGMT_USERNAME
+and MGMT_PASSWORD environment variables).
+
+Spotify endpoints are only available when SPOTIFY_CLIENT_ID and
+SPOTIFY_CLIENT_SECRET are configured.
+"""
+
+import logging
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from soundcork.config import Settings
+from soundcork.datastore import DataStore
+from soundcork.mgmt_auth import verify_credentials
+from soundcork.spotify_service import SpotifyService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/mgmt", tags=["management"])
+
+datastore = DataStore()
+settings = Settings()
+spotify = SpotifyService()
+
+
+# --- Speaker Management ---
+
+
+@router.get("/accounts/{account_id}/speakers")
+def list_speakers(
+    account_id: str,
+    _user: str = Depends(verify_credentials),
+):
+    """List all speakers for an account.
+
+    Returns IP addresses and basic info for each device.
+    """
+    try:
+        device_ids = datastore.list_devices(account_id)
+    except (StopIteration, FileNotFoundError):
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    speakers = []
+    for device_id in device_ids:
+        try:
+            info = datastore.get_device_info(account_id, device_id)
+            speakers.append(
+                {
+                    "ipAddress": info.ip_address,
+                    "name": info.name,
+                    "deviceId": info.device_id,
+                    "type": info.product_code,
+                }
+            )
+        except Exception:
+            logger.warning("Failed to read device info for %s", device_id)
+            continue
+
+    return {"speakers": speakers}
+
+
+# --- Device Events ---
+
+
+@router.get("/devices/{device_id}/events")
+def list_device_events(
+    device_id: str,
+    _user: str = Depends(verify_credentials),
+):
+    """List events for a device.
+
+    Currently returns an empty list. Can be extended to log
+    power_on events, preset changes, etc.
+    """
+    return {"events": []}
+
+
+# --- Spotify ---
+
+
+@router.post("/spotify/init")
+def spotify_init(
+    request: Request,
+    _user: str = Depends(verify_credentials),
+):
+    """Start the Spotify OAuth flow.
+
+    Returns a redirect URL that the caller should open in a browser.
+    After authorization, Spotify redirects to the configured redirect_uri
+    with an authorization code.
+    """
+    if not settings.spotify_client_id:
+        raise HTTPException(
+            status_code=503,
+            detail="Spotify integration not configured (missing SPOTIFY_CLIENT_ID)",
+        )
+
+    authorize_url = spotify.build_authorize_url()
+    return {"redirectUrl": authorize_url}
+
+
+@router.get("/spotify/init")
+def spotify_init_browser(request: Request):
+    """Start the Spotify OAuth flow via browser redirect.
+
+    Unlike POST /spotify/init, this endpoint redirects the browser
+    directly to Spotify with the server-side callback URL, so the
+    entire flow happens in the browser.
+
+    No Basic Auth required -- the callback is on this server.
+    """
+    if not settings.spotify_client_id:
+        raise HTTPException(
+            status_code=503,
+            detail="Spotify integration not configured (missing SPOTIFY_CLIENT_ID)",
+        )
+
+    # Use the server callback URL. We use settings.base_url rather than
+    # request.base_url because the app may sit behind a TLS-terminating
+    # reverse proxy and request.base_url would return http://.
+    callback_url = settings.base_url.rstrip("/") + "/mgmt/spotify/callback"
+    authorize_url = spotify.build_authorize_url(redirect_uri=callback_url)
+
+    return RedirectResponse(url=authorize_url)
+
+
+@router.get("/spotify/callback", response_class=HTMLResponse)
+async def spotify_callback(
+    request: Request,
+    code: Annotated[str | None, Query()] = None,
+    error: Annotated[str | None, Query()] = None,
+):
+    """Server-side OAuth callback.
+
+    This endpoint is NOT protected by Basic Auth because Spotify
+    redirects the user's browser here directly.
+    """
+    if error:
+        return HTMLResponse(
+            content=f"<html><body><h1>Spotify Authorization Failed</h1>"
+            f"<p>Error: {error}</p></body></html>",
+            status_code=400,
+        )
+
+    if not code:
+        return HTMLResponse(
+            content="<html><body><h1>Missing authorization code</h1></body></html>",
+            status_code=400,
+        )
+
+    try:
+        callback_url = settings.base_url.rstrip("/") + "/mgmt/spotify/callback"
+        account = await spotify.exchange_code_and_store(code, redirect_uri=callback_url)
+        return HTMLResponse(
+            content=f"<html><body>"
+            f"<h1>Spotify Connected</h1>"
+            f"<p>Linked account: {account['displayName']} ({account['spotifyUserId']})</p>"
+            f"<p>You can close this window.</p>"
+            f"</body></html>"
+        )
+    except Exception as e:
+        logger.exception("Spotify callback failed")
+        return HTMLResponse(
+            content=f"<html><body><h1>Error</h1><p>{e}</p></body></html>",
+            status_code=500,
+        )
+
+
+@router.post("/spotify/confirm")
+async def spotify_confirm(
+    code: Annotated[str, Query()],
+    _user: str = Depends(verify_credentials),
+):
+    """Confirm Spotify authorization with an authorization code.
+
+    Used by mobile apps after a deep link callback delivers the code.
+    Exchanges the code for tokens and stores the account.
+    """
+    if not settings.spotify_client_id:
+        raise HTTPException(
+            status_code=503,
+            detail="Spotify integration not configured",
+        )
+
+    try:
+        await spotify.exchange_code_and_store(code)
+    except Exception as e:
+        logger.exception("Spotify confirm failed")
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return {"ok": True}
+
+
+@router.get("/spotify/accounts")
+def spotify_accounts(
+    _user: str = Depends(verify_credentials),
+):
+    """List connected Spotify accounts (tokens stripped)."""
+    accounts = spotify.list_accounts()
+    return {
+        "accounts": [
+            {
+                "displayName": a["displayName"],
+                "createdAt": a["createdAt"],
+                "spotifyUserId": a["spotifyUserId"],
+            }
+            for a in accounts
+        ]
+    }
+
+
+@router.post("/spotify/entity")
+async def spotify_entity(
+    request: Request,
+    _user: str = Depends(verify_credentials),
+):
+    """Resolve a Spotify URI to a name and image URL.
+
+    Useful when storing Spotify presets -- resolves the track/album/
+    playlist name and cover art URL.
+    """
+    body = await request.json()
+    uri = body.get("uri", "")
+
+    if not uri or not uri.startswith("spotify:"):
+        raise HTTPException(status_code=400, detail={"message": "Invalid Spotify URI"})
+
+    try:
+        entity = await spotify.resolve_entity(uri)
+        return entity
+    except Exception as e:
+        logger.exception("Failed to resolve Spotify entity: %s", uri)
+        raise HTTPException(status_code=500, detail=str(e))

--- a/soundcork/mgmt_auth.py
+++ b/soundcork/mgmt_auth.py
@@ -1,0 +1,33 @@
+import secrets
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+
+from soundcork.config import Settings
+
+security = HTTPBasic()
+settings = Settings()
+
+
+def verify_credentials(
+    credentials: HTTPBasicCredentials = Depends(security),
+) -> str:
+    """Verify HTTP Basic Auth credentials for management endpoints.
+
+    Returns the username on success, raises 401 on failure.
+    """
+    username_ok = secrets.compare_digest(
+        credentials.username.encode("utf-8"),
+        settings.mgmt_username.encode("utf-8"),
+    )
+    password_ok = secrets.compare_digest(
+        credentials.password.encode("utf-8"),
+        settings.mgmt_password.encode("utf-8"),
+    )
+    if not (username_ok and password_ok):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return credentials.username

--- a/soundcork/spotify_service.py
+++ b/soundcork/spotify_service.py
@@ -1,0 +1,246 @@
+"""Spotify OAuth and Web API integration.
+
+Handles the authorization code flow, token management, and entity
+resolution for Spotify-connected speakers.
+
+All Spotify functionality is optional -- if SPOTIFY_CLIENT_ID is not
+configured, the management API gracefully disables Spotify endpoints.
+"""
+
+import json
+import logging
+import os
+import time
+import urllib.parse
+from datetime import datetime, timezone
+
+import httpx
+
+from soundcork.config import Settings
+
+logger = logging.getLogger(__name__)
+
+SPOTIFY_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
+SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
+SPOTIFY_API_BASE = "https://api.spotify.com/v1"
+
+# Scopes needed for user profile and entity resolution.
+# Add "streaming" and "user-modify-playback-state" if you plan to
+# control playback via the Spotify Web API.
+SPOTIFY_SCOPES = "user-read-private user-read-email"
+
+
+class SpotifyService:
+    def __init__(self):
+        self._settings = Settings()
+        self._accounts_file = os.path.join(
+            self._settings.data_dir, "spotify", "accounts.json"
+        )
+
+    def _ensure_spotify_dir(self):
+        """Create the spotify data directory if it doesn't exist."""
+        spotify_dir = os.path.dirname(self._accounts_file)
+        os.makedirs(spotify_dir, exist_ok=True)
+
+    def _load_accounts(self) -> list[dict]:
+        """Load stored Spotify accounts from disk."""
+        if not os.path.isfile(self._accounts_file):
+            return []
+        try:
+            with open(self._accounts_file, "r") as f:
+                return json.load(f)
+        except (json.JSONDecodeError, OSError):
+            logger.warning("Failed to read Spotify accounts file")
+            return []
+
+    def _save_accounts(self, accounts: list[dict]):
+        """Save Spotify accounts to disk."""
+        self._ensure_spotify_dir()
+        with open(self._accounts_file, "w") as f:
+            json.dump(accounts, f, indent=2)
+
+    def build_authorize_url(self, redirect_uri: str | None = None) -> str:
+        """Build the Spotify authorization URL for the OAuth flow.
+
+        Args:
+            redirect_uri: Override the default redirect URI (e.g. for
+                server-side callback vs mobile deep link).
+        """
+        params = {
+            "client_id": self._settings.spotify_client_id,
+            "response_type": "code",
+            "redirect_uri": redirect_uri or self._settings.spotify_redirect_uri,
+            "scope": SPOTIFY_SCOPES,
+        }
+        return f"{SPOTIFY_AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
+
+    async def exchange_code_and_store(
+        self, code: str, redirect_uri: str | None = None
+    ) -> dict:
+        """Exchange an authorization code for tokens and store the account.
+
+        Args:
+            code: The authorization code from Spotify.
+            redirect_uri: The redirect URI that was used in the authorize
+                request. Must match exactly or Spotify rejects it.
+
+        Returns the stored account dict.
+        """
+        token_data = await self._exchange_code(code, redirect_uri)
+
+        access_token = token_data["access_token"]
+        refresh_token = token_data.get("refresh_token", "")
+        expires_in = token_data.get("expires_in", 3600)
+
+        profile = await self._get_user_profile(access_token)
+
+        account = {
+            "displayName": profile.get("display_name", "Unknown"),
+            "spotifyUserId": profile["id"],
+            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "tokenExpiresAt": int(time.time()) + expires_in,
+        }
+
+        # Upsert: replace if same user ID already exists
+        accounts = self._load_accounts()
+        accounts = [
+            a for a in accounts if a["spotifyUserId"] != account["spotifyUserId"]
+        ]
+        accounts.append(account)
+        self._save_accounts(accounts)
+
+        logger.info("Spotify account linked: %s", account["displayName"])
+        return account
+
+    async def _exchange_code(self, code: str, redirect_uri: str | None = None) -> dict:
+        """Exchange an authorization code for access and refresh tokens."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                SPOTIFY_TOKEN_URL,
+                data={
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "redirect_uri": redirect_uri or self._settings.spotify_redirect_uri,
+                },
+                auth=(
+                    self._settings.spotify_client_id,
+                    self._settings.spotify_client_secret,
+                ),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+        if response.status_code != 200:
+            error_detail = response.text
+            logger.error("Spotify token exchange failed: %s", error_detail)
+            raise RuntimeError(f"Spotify token exchange failed: {error_detail}")
+
+        return response.json()
+
+    async def _refresh_access_token(self, refresh_token: str) -> dict:
+        """Refresh an expired access token."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                SPOTIFY_TOKEN_URL,
+                data={
+                    "grant_type": "refresh_token",
+                    "refresh_token": refresh_token,
+                },
+                auth=(
+                    self._settings.spotify_client_id,
+                    self._settings.spotify_client_secret,
+                ),
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+
+        if response.status_code != 200:
+            raise RuntimeError(f"Spotify token refresh failed: {response.text}")
+
+        return response.json()
+
+    async def _get_valid_token(self) -> str:
+        """Get a valid access token, refreshing if necessary."""
+        accounts = self._load_accounts()
+        if not accounts:
+            raise RuntimeError("No Spotify accounts linked")
+
+        account = accounts[0]
+        now = int(time.time())
+
+        if now >= account.get("tokenExpiresAt", 0) - 60:
+            refresh_token = account.get("refreshToken", "")
+            if not refresh_token:
+                raise RuntimeError("No refresh token available")
+
+            token_data = await self._refresh_access_token(refresh_token)
+            account["accessToken"] = token_data["access_token"]
+            account["tokenExpiresAt"] = now + token_data.get("expires_in", 3600)
+            if "refresh_token" in token_data:
+                account["refreshToken"] = token_data["refresh_token"]
+            self._save_accounts(accounts)
+
+        return account["accessToken"]
+
+    async def _get_user_profile(self, access_token: str) -> dict:
+        """Fetch the current user's Spotify profile."""
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{SPOTIFY_API_BASE}/me",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+        if response.status_code != 200:
+            raise RuntimeError(f"Failed to fetch Spotify profile: {response.text}")
+
+        return response.json()
+
+    def list_accounts(self) -> list[dict]:
+        """List all stored Spotify accounts."""
+        return self._load_accounts()
+
+    async def resolve_entity(self, uri: str) -> dict:
+        """Resolve a Spotify URI to a name and image URL.
+
+        Supports: spotify:track:ID, spotify:album:ID,
+        spotify:playlist:ID, spotify:artist:ID
+        """
+        parts = uri.split(":")
+        if len(parts) != 3:
+            raise ValueError(f"Invalid Spotify URI format: {uri}")
+
+        entity_type = parts[1]
+        entity_id = parts[2]
+
+        valid_types = {"track", "album", "playlist", "artist"}
+        if entity_type not in valid_types:
+            raise ValueError(f"Unsupported Spotify entity type: {entity_type}")
+
+        api_type = entity_type + "s"
+        access_token = await self._get_valid_token()
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                f"{SPOTIFY_API_BASE}/{api_type}/{entity_id}",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+
+        if response.status_code == 404:
+            raise ValueError("Spotify entity not found")
+
+        if response.status_code != 200:
+            raise RuntimeError(f"Spotify API error: {response.text}")
+
+        data = response.json()
+        name = data.get("name", "Unknown")
+
+        image_url = None
+        images = data.get("images", [])
+        if not images and entity_type == "track":
+            album_images = data.get("album", {}).get("images", [])
+            if album_images:
+                image_url = album_images[0].get("url")
+        elif images:
+            image_url = images[0].get("url")
+
+        return {"name": name, "imageUrl": image_url}

--- a/soundcork/zeroconf_primer.py
+++ b/soundcork/zeroconf_primer.py
@@ -1,0 +1,391 @@
+"""Spotify ZeroConf primer for SoundTouch speakers.
+
+After Bose's cloud servers shut down, speakers can no longer obtain
+Spotify credentials via the marge /full account response.  Instead,
+we prime speakers by sending a valid Spotify access token directly
+to their ZeroConf endpoint (port 8200) using the addUser action.
+
+This is the same mechanism the Spotify desktop app uses: a plain
+access token is sent as the blob parameter (no DH encryption).
+
+Speakers are tracked dynamically: when a speaker contacts any marge
+endpoint, its account/device ID is captured and its IP is looked up
+from the datastore.  This avoids the need to scan directories and
+ensures newly added speakers are primed automatically.
+
+The primer runs:
+  - On speaker boot (triggered by the power_on endpoint), with retry
+  - When a new speaker is seen for the first time
+  - Periodically to keep sessions alive before tokens expire (1 hour)
+
+Configuration:
+  - SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set
+  - A Spotify account must be linked via the management API
+  - Speaker IP addresses are read from the datastore (DeviceInfo)
+"""
+
+import json
+import logging
+import threading
+import time
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+
+from soundcork.config import Settings
+from soundcork.datastore import DataStore
+from soundcork.spotify_service import SpotifyService
+
+logger = logging.getLogger(__name__)
+
+ZEROCONF_PORT = 8200
+PERIODIC_CHECK_SECONDS = 45 * 60  # 45 minutes
+BOOT_RETRY_DELAYS = [5, 10, 20]  # seconds between retries after power_on
+MAX_CONSECUTIVE_FAILURES = 5  # remove speaker from registry after this many
+
+
+@dataclass
+class TrackedSpeaker:
+    """A speaker that has been seen by soundcork."""
+
+    account_id: str
+    device_id: str
+    ip_address: str | None = None
+    last_primed: float = 0.0  # timestamp of last successful prime
+    prime_failures: int = 0
+
+
+class ZeroConfPrimer:
+    def __init__(
+        self,
+        spotify: SpotifyService,
+        datastore: DataStore,
+        settings: Settings,
+    ):
+        self._spotify = spotify
+        self._datastore = datastore
+        self._settings = settings
+        self._timer: threading.Timer | None = None
+        self._speakers: dict[str, TrackedSpeaker] = {}  # device_id -> TrackedSpeaker
+        self._lock = threading.Lock()
+        self._cached_token: str | None = None
+        self._token_expires_at: float = 0.0
+
+    # --- Speaker registration ---
+
+    def register_speaker(self, account_id: str, device_id: str):
+        """Register a speaker that contacted a marge endpoint.
+
+        Called from marge request handlers.  If this is a new speaker,
+        resolves its IP and primes it in the background.
+        """
+        if not self._settings.spotify_client_id:
+            return
+
+        is_new = False
+        with self._lock:
+            if device_id not in self._speakers:
+                ip = self._resolve_speaker_ip(account_id, device_id)
+                self._speakers[device_id] = TrackedSpeaker(
+                    account_id=account_id,
+                    device_id=device_id,
+                    ip_address=ip,
+                )
+                is_new = True
+                logger.info(
+                    "New speaker registered: %s (account=%s, ip=%s)",
+                    device_id,
+                    account_id,
+                    ip,
+                )
+            else:
+                # Update account_id in case it changed
+                self._speakers[device_id].account_id = account_id
+
+        if is_new:
+            speaker = self._speakers[device_id]
+            if speaker.ip_address:
+                threading.Thread(
+                    target=self._prime_if_needed,
+                    args=(speaker,),
+                    daemon=True,
+                ).start()
+
+    def on_power_on(self, source_ip: str | None = None):
+        """Called when a speaker sends power_on.
+
+        Primes all known speakers with retry/backoff, since the
+        speaker's ZeroConf port may not be ready immediately.
+        If no speakers are registered yet, discovers from datastore.
+        """
+        if not self._settings.spotify_client_id:
+            return
+
+        threading.Thread(
+            target=self._power_on_prime,
+            args=(source_ip,),
+            daemon=True,
+        ).start()
+
+    # --- Periodic ---
+
+    def start_periodic(self):
+        """Start the periodic re-prime background task."""
+        if not self._settings.spotify_client_id:
+            logger.info("Spotify not configured — periodic primer disabled")
+            return
+
+        # Seed the registry from the datastore on startup
+        self._seed_from_datastore()
+
+        self._schedule_next()
+        logger.info(
+            "Periodic Spotify primer started (every %d minutes)",
+            PERIODIC_CHECK_SECONDS // 60,
+        )
+
+    def stop_periodic(self):
+        """Stop the periodic re-prime background task."""
+        if self._timer:
+            self._timer.cancel()
+            self._timer = None
+
+    # --- Internal ---
+
+    def _seed_from_datastore(self):
+        """Populate the speaker registry from the datastore on startup."""
+        import os
+
+        data_dir = self._settings.data_dir
+        if not data_dir or not os.path.isdir(data_dir):
+            return
+
+        for account_id in os.listdir(data_dir):
+            account_path = os.path.join(data_dir, account_id)
+            if not os.path.isdir(account_path):
+                continue
+
+            try:
+                device_ids = self._datastore.list_devices(account_id)
+            except (StopIteration, FileNotFoundError):
+                continue
+
+            for device_id in device_ids:
+                if not device_id:
+                    continue
+                ip = self._resolve_speaker_ip(account_id, device_id)
+                if ip:
+                    with self._lock:
+                        if device_id not in self._speakers:
+                            self._speakers[device_id] = TrackedSpeaker(
+                                account_id=account_id,
+                                device_id=device_id,
+                                ip_address=ip,
+                            )
+
+        count = len(self._speakers)
+        if count:
+            logger.info("Seeded %d speaker(s) from datastore", count)
+
+    def _resolve_speaker_ip(self, account_id: str, device_id: str) -> str | None:
+        """Look up a speaker's IP address from the datastore."""
+        try:
+            info = self._datastore.get_device_info(account_id, device_id)
+            return info.ip_address
+        except Exception:
+            logger.debug("Could not resolve IP for %s/%s", account_id, device_id)
+            return None
+
+    def _get_token(self) -> tuple[str, str] | None:
+        """Get a valid Spotify access token and user ID.
+
+        Caches the token to avoid refreshing for every speaker.
+        Returns (token, user_id) or None.
+        """
+        user_id = self._spotify.get_spotify_user_id()
+        if not user_id:
+            logger.warning("No Spotify user ID configured")
+            return None
+
+        now = time.time()
+        if self._cached_token and now < self._token_expires_at - 120:
+            return self._cached_token, user_id
+
+        token = self._spotify.get_fresh_token_sync()
+        if not token:
+            logger.warning("Could not get Spotify access token")
+            return None
+
+        self._cached_token = token
+        self._token_expires_at = now + 3600  # tokens last 1 hour
+        return token, user_id
+
+    def _prime_if_needed(self, speaker: TrackedSpeaker) -> bool:
+        """Check activeUser and prime only if empty."""
+        if not speaker.ip_address:
+            return False
+
+        try:
+            active_user = self._get_active_user(speaker.ip_address)
+            if active_user:
+                logger.debug(
+                    "Speaker %s already primed (activeUser=%s)",
+                    speaker.ip_address,
+                    active_user,
+                )
+                speaker.last_primed = time.time()
+                return True
+        except Exception:
+            logger.debug("Could not check activeUser for %s", speaker.ip_address)
+
+        return self._prime_speaker(speaker)
+
+    def _prime_speaker(self, speaker: TrackedSpeaker) -> bool:
+        """Send addUser to a speaker."""
+        if not speaker.ip_address:
+            return False
+
+        creds = self._get_token()
+        if not creds:
+            return False
+        token, user_id = creds
+
+        try:
+            result = self._send_add_user(speaker.ip_address, user_id, token)
+            status = result.get("status", -1)
+            if status != 101:
+                logger.warning(
+                    "addUser to %s returned status %s: %s",
+                    speaker.ip_address,
+                    status,
+                    result.get("statusString", ""),
+                )
+                speaker.prime_failures += 1
+                return False
+
+            logger.info("addUser accepted by %s (status 101)", speaker.ip_address)
+
+            # Verify activeUser was set
+            time.sleep(2)
+            active_user = self._get_active_user(speaker.ip_address)
+            if active_user:
+                logger.info(
+                    "Speaker %s primed for Spotify (activeUser=%s)",
+                    speaker.ip_address,
+                    active_user,
+                )
+                speaker.last_primed = time.time()
+                speaker.prime_failures = 0
+                return True
+            else:
+                logger.warning(
+                    "Speaker %s returned 101 but activeUser still empty",
+                    speaker.ip_address,
+                )
+                speaker.prime_failures += 1
+                return False
+
+        except Exception:
+            logger.exception("Failed to prime speaker %s", speaker.ip_address)
+            speaker.prime_failures += 1
+            return False
+
+    def _power_on_prime(self, source_ip: str | None):
+        """Prime speakers after boot with retry/backoff."""
+        with self._lock:
+            speakers = list(self._speakers.values())
+
+        if not speakers:
+            logger.info("No speakers registered — nothing to prime")
+            return
+
+        for delay in BOOT_RETRY_DELAYS:
+            logger.info(
+                "Speaker booted — waiting %ds before priming %d speaker(s)...",
+                delay,
+                len(speakers),
+            )
+            time.sleep(delay)
+
+            all_ok = True
+            for speaker in speakers:
+                if not speaker.ip_address:
+                    continue
+                if not self._prime_if_needed(speaker):
+                    all_ok = False
+
+            if all_ok:
+                logger.info("All speakers primed successfully")
+                return
+
+        logger.warning("Some speakers failed to prime after all retries")
+
+    def _schedule_next(self):
+        """Schedule the next periodic check."""
+        self._timer = threading.Timer(PERIODIC_CHECK_SECONDS, self._periodic_tick)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _periodic_tick(self):
+        """Periodic task: check and re-prime all speakers if needed."""
+        try:
+            logger.info("Periodic Spotify primer check running...")
+            with self._lock:
+                speakers = list(self._speakers.values())
+
+            for speaker in speakers:
+                self._prime_if_needed(speaker)
+
+            # Remove speakers that have failed too many times in a row.
+            # They get re-added automatically when they contact marge
+            # or send a power_on event.
+            with self._lock:
+                to_remove = [
+                    did
+                    for did, s in self._speakers.items()
+                    if s.prime_failures >= MAX_CONSECUTIVE_FAILURES
+                ]
+                for did in to_remove:
+                    s = self._speakers.pop(did)
+                    logger.warning(
+                        "Removed unreachable speaker %s (%s) after %d consecutive failures",
+                        did,
+                        s.ip_address,
+                        s.prime_failures,
+                    )
+
+        except Exception:
+            logger.exception("Error during periodic Spotify primer")
+        finally:
+            self._schedule_next()
+
+    @staticmethod
+    def _send_add_user(speaker_ip: str, user_id: str, token: str) -> dict:
+        """Send addUser to the speaker's ZeroConf endpoint."""
+        post_data = urllib.parse.urlencode(
+            {
+                "action": "addUser",
+                "userName": user_id,
+                "blob": token,
+                "clientKey": "",
+                "tokenType": "accesstoken",
+            }
+        ).encode()
+
+        url = f"http://{speaker_ip}:{ZEROCONF_PORT}/zc"
+        req = urllib.request.Request(
+            url,
+            data=post_data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+
+    @staticmethod
+    def _get_active_user(speaker_ip: str) -> str:
+        """Check the speaker's activeUser via ZeroConf getInfo."""
+        url = f"http://{speaker_ip}:{ZEROCONF_PORT}/zc?action=getInfo"
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            info = json.loads(resp.read())
+        return info.get("activeUser", "")


### PR DESCRIPTION
## Summary

Adds full Spotify preset support to soundcork, with two complementary mechanisms that keep Spotify working after the Bose cloud shutdown.

### OAuth Token Intercept (Primary)

The speaker firmware has built-in token refresh logic — it calls `POST /oauth/device/{deviceId}/music/musicprovider/15/token/cs3` to get fresh Spotify tokens. This endpoint intercepts those requests and returns a valid token from the linked Spotify account.

This is transparent to the speaker — it manages its own refresh cycle, just like it did with Bose's `streamingoauth.bose.com` server.

### ZeroConf Primer (Optional Fallback)

Proactively pushes Spotify tokens to speakers via the ZeroConf `addUser` endpoint (port 8200). Runs on speaker boot and periodically. Uses the same mechanism the Spotify desktop app uses.

### Management API

Provides endpoints for linking Spotify accounts via OAuth and managing speaker configuration:
- `POST /mgmt/spotify/auth/init` — start OAuth flow
- `GET /mgmt/spotify/auth/callback` — complete OAuth flow
- `GET /mgmt/spotify/accounts` — list linked accounts
- `GET /mgmt/speakers` — list tracked speakers
- `GET /mgmt/events` — view speaker events

### Setup

1. Register a Spotify app at developer.spotify.com
2. Set `SPOTIFY_CLIENT_ID` and `SPOTIFY_CLIENT_SECRET` environment variables
3. Link your Spotify account via the management API
4. Spotify presets work automatically — no manual intervention needed

### Files

- `soundcork/spotify_service.py` — Spotify OAuth token management
- `soundcork/mgmt.py` — Management API router
- `soundcork/mgmt_auth.py` — HTTP Basic Auth
- `soundcork/zeroconf_primer.py` — Optional ZeroConf primer
- `soundcork/config.py` — New settings (Spotify credentials, mgmt auth)
- `soundcork/main.py` — OAuth endpoint, primer wiring, speaker middleware
- `docs/spotify.md` — Setup guide and technical documentation

### Testing

Tested end-to-end on a SoundTouch 20 (firmware 27.0.6):
- OAuth intercept confirmed working — speaker calls endpoint and receives fresh tokens
- ZeroConf primer confirmed working — cold boot → auto-prime → Spotify presets play
- Both approaches coexist without interference

Resolves #107, #159
Related: #186