### PR TITLE
Fix issue where device expects 201 status response #53

### DIFF
--- a/soundcork/main.py
+++ b/soundcork/main.py
@@ -299,6 +299,7 @@ async def post_account_recent(
     "/marge/streaming/account/{account}/device/",
     response_class=BoseXMLResponse,
     tags=["marge"],
+    status_code=201,
     dependencies=[
         Depends(
             Etag(


### PR DESCRIPTION
This PR fixes the issue where the device expects a 201 status response when adding device to your account.
Sorry, my original API spec was missing the status response, so 200 was implemented.
However the device reports failed when returning 200 - and success when returning 201.