### PR TITLE
POST /v1/scmudc/{deviceid}

### DIFF
--- a/soundcork/main.py
+++ b/soundcork/main.py
@@ -409,6 +409,10 @@ def sw_update() -> Response:
 
 @app.post("/v1/scmudc/{deviceid}", tags=["stats"], status_code=HTTPStatus.OK)
 def stats_scmudc(deviceid: str):
+    """Returns 200 for the analytics endpoint.
+    
+    This isn't an endpoint we use, but it's noisy when it fails. Return 200.
+    """
     return
 
 


### PR DESCRIPTION
Solves #200, keeps device happy by returning 200 OK.