### PR TITLE
Solve #219: docker compose with ETag support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+name: ghcr-soundcork-main
+services:
+  soundcork:
+    image: ghcr.io/deborahgu/soundcork:main
+    ports:
+      - "8000:8000"
+    environment:
+      - base_url=http://192.168.2.180:8001
+      - data_dir=/soundcork/data
+      - SOUNDCORK_MODE=local
+      - SOUNDCORK_LOG_DIR=/soundcork/logs/traffic
+    volumes:
+      - ./data:/soundcork/data
+      - ./logs:/soundcork/logs
+    restart: unless-stopped
+  nginx-etag: # see https://github.com/deborahgu/soundcork/issues/129
+    image: nginx
+    container_name: nginx-ETag
+    ports:
+      - "8001:8001"
+    volumes:
+      - ./nginx-ETag.conf:/etc/nginx/conf.d/default.conf:ro
+    restart: unless-stopped
+
+# docker compose up
+# docker compose start
+# docker compose logs -f
+# docker compose stop

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,14 @@
-name: ghcr-soundcork-main
+name: soundcork
 services:
   soundcork:
     image: ghcr.io/deborahgu/soundcork:main
+    container_name: ghcr-soundcork-main
     ports:
       - "8000:8000"
     environment:
-      - base_url=http://192.168.2.180:8001
+      # Configure the base url where soundcork is hosted.
+      # Use port 8000 for direct access or port 8001 for access through nginx-ETag.
+      - base_url=http://soundcork:8001
       - data_dir=/soundcork/data
       - SOUNDCORK_MODE=local
       - SOUNDCORK_LOG_DIR=/soundcork/logs/traffic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-name: soundcork
 services:
   soundcork:
     image: ghcr.io/deborahgu/soundcork:main
-    container_name: ghcr-soundcork-main
     ports:
       - "8000:8000"
     environment:

--- a/nginx-ETag.conf
+++ b/nginx-ETag.conf
@@ -1,9 +1,9 @@
 server {
-    listen 80;
+    listen 8001;
 
     location / {
-        # replace with your server's IP address and port
-        proxy_pass http://192.168.1.2:8000;
+        # When not using docker compose replace with your server's IP address and port
+        proxy_pass http://soundcork:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
 

--- a/run_nginx.sh
+++ b/run_nginx.sh
@@ -1,4 +1,4 @@
 # Workaround to produce ETag headers for soundtouch device compatibility
 # See also: https://github.com/deborahgu/soundcork/issues/129
-
-docker run --rm --name nginx-ETag -p 8002:80 -v $(pwd)/nginx-ETag.conf:/etc/nginx/conf.d/default.conf:ro nginx
+# You have to set the soundcork IP in nginx-Etag.conf
+docker run --rm --name nginx-ETag -p 8001:8001 -v $(pwd)/nginx-ETag.conf:/etc/nginx/conf.d/default.conf:ro nginx


### PR DESCRIPTION
This setup starts soundcork as well as nginx for proper ETag support.
Maybe later we can bake both services in one container.
Solves #219 
