### PR TITLE
fix: tunein search and navigation

### DIFF
--- a/soundcork/bmx.py
+++ b/soundcork/bmx.py
@@ -37,6 +37,34 @@ TUNEIN_SEARCH = (
 )
 
 
+def tunein_is_opml_uri(tunein_uri: str) -> bool:
+    parsed_uri = urllib.parse.urlsplit(tunein_uri)
+    return parsed_uri.netloc.lower() == "opml.radiotime.com"
+
+
+def tunein_search_uri(query: str) -> str:
+    return f"{TUNEIN_SEARCH}{urllib.parse.quote_plus(query)}"
+
+
+def tunein_render_json_uri(tunein_uri: str) -> str:
+    if not tunein_uri:
+        return ""
+
+    parsed_uri = urllib.parse.urlsplit(tunein_uri)
+    query_params = [
+        (key, value)
+        for key, value in urllib.parse.parse_qsl(
+            parsed_uri.query, keep_blank_values=True
+        )
+        if key.lower() != "render"
+    ]
+    query_params.append(("render", "json"))
+
+    return urllib.parse.urlunsplit(
+        parsed_uri._replace(query=urllib.parse.urlencode(query_params))
+    )
+
+
 # TODO:  determine how listen_id is used, if at all
 # TODO:  determine how stream_id is used, if at all
 # TODO:  see if there is a value to varying the timeout values
@@ -270,7 +298,7 @@ def tunein_navigate_v1(
             "templated": True,
         }
 
-    if tunein_uri.startswith(TUNEIN_NAVIGATE_ASHX):
+    if tunein_is_opml_uri(tunein_uri):
         # this builds all of the sections for ashx
         sections = tunein_sections_ashx(tunein_uri, subsection)
     else:
@@ -399,7 +427,7 @@ def tunein_navigate_playitem(item: dict) -> BmxNavItem:
 
 
 def tunein_navigate_link(item: dict) -> BmxNavItem:
-    url = f'{item.get("URL", "")}&render=json'
+    url = tunein_render_json_uri(item.get("URL", ""))
     enc_url = base64.urlsafe_b64encode(url.encode()).decode()
     return BmxNavItem(
         links={
@@ -440,7 +468,7 @@ def tunein_sections_jsonapi(
             if item.get("ContainerType", "") != "NotPlayableStations":
                 sections.append(tunein_search_section(item, idx, ""))
         else:
-            logger.info(f"top-level nav not a container: {item.type}")
+            logger.info(f"top-level nav not a container: {item.get('Type', '')}")
 
     if subsection is not None:
         subsection_part = f"sub/{subsection}/"
@@ -513,7 +541,7 @@ def tunein_navigate_profile_v1(encoded_uri: str = "") -> BmxNavResponse:
 
 def tunein_search_v1(query: str, subsection: str | None = None) -> BmxNavResponse:
 
-    tunein_uri = f"{TUNEIN_SEARCH}{query}"
+    tunein_uri = tunein_search_uri(query)
     bmx_search_link = {
         "filters": [],
         "href": "/v1/search?q={query}",
@@ -535,10 +563,10 @@ def tunein_search_v1(query: str, subsection: str | None = None) -> BmxNavRespons
             if item.get("ContainerType", "") != "NotPlayableStations":
                 sections.append(tunein_search_section(item, idx, query))
         else:
-            logger.info(f"top-level search not a container: {item.type}")
+            logger.info(f"top-level search not a container: {item.get('Type', '')}")
 
     links = {
-        "self": {"href": f"/v1/search/q={query}"},
+        "self": {"href": f"/v1/search?{urllib.parse.urlencode({'q': query})}"},
     }
     return BmxNavResponse(
         links=links,
@@ -551,9 +579,7 @@ def tunein_search_section(
     item: dict, idx: int, query: str, layout: str = "shortList"
 ) -> BmxNavSection:
     pivot_url = item.get("Pivots", {}).get("More", {}).get("Url", "")
-    encoded_query = base64.urlsafe_b64encode(
-        f"{TUNEIN_SEARCH}{query}".encode()
-    ).decode()
+    encoded_query = base64.urlsafe_b64encode(tunein_search_uri(query).encode()).decode()
     if pivot_url:
         href = f"/v1/navigate/{base64.urlsafe_b64encode(pivot_url.encode()).decode()}"
     else:
@@ -667,7 +693,7 @@ def tunein_search_profile(item: dict, name: str) -> BmxNavItem:
 
 
 def tunein_search_link(item: dict) -> BmxNavItem:
-    url = f'{item.get("URL", "")}&render=json'
+    url = tunein_render_json_uri(item.get("URL", ""))
     enc_url = base64.urlsafe_b64encode(url.encode()).decode()
     return BmxNavItem(
         links={

--- a/soundcork/tests/test_bmx.py
+++ b/soundcork/tests/test_bmx.py
@@ -1,0 +1,105 @@
+import base64
+import json
+import urllib.parse
+
+from soundcork.bmx import tunein_navigate_v1, tunein_search_v1
+
+
+class FakeTuneInResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def encode_uri(uri: str) -> str:
+    return base64.urlsafe_b64encode(uri.encode()).decode()
+
+
+def decode_navigate_href(href: str) -> str:
+    return base64.urlsafe_b64decode(href.rsplit("/", 1)[-1]).decode()
+
+
+def test_navigate_uses_ashx_parser_for_opml_browse_urls(monkeypatch):
+    tunein_uri = "http://opml.radiotime.com/Browse.ashx?c=podcast&render=json"
+    requested_urls = []
+
+    def fake_urlopen(url):
+        requested_urls.append(url)
+        return FakeTuneInResponse(
+            {
+                "head": {"title": "Podcasts"},
+                "body": [
+                    {
+                        "type": "link",
+                        "text": "News",
+                        "subtext": "Latest episodes",
+                        "image": "http://example.com/news.png",
+                        "URL": "http://opml.radiotime.com/Browse.ashx?c=news",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr("soundcork.bmx.urllib.request.urlopen", fake_urlopen)
+
+    response = tunein_navigate_v1(encode_uri(tunein_uri))
+
+    assert requested_urls == [tunein_uri]
+    assert response.bmx_sections[0].name == "Podcasts"
+    assert response.bmx_sections[0].items[0].name == "News"
+
+    navigate_href = response.bmx_sections[0].items[0].links.bmx_navigate.href
+    assert (
+        decode_navigate_href(navigate_href)
+        == "http://opml.radiotime.com/Browse.ashx?c=news&render=json"
+    )
+
+
+def test_search_url_encodes_spaces_and_more_link_uses_encoded_query(monkeypatch):
+    requested_urls = []
+
+    def fake_urlopen(url):
+        requested_urls.append(url)
+        return FakeTuneInResponse(
+            {
+                "Items": [
+                    {
+                        "Type": "Container",
+                        "ContainerType": "PlayableStations",
+                        "Title": "Stations",
+                        "Children": [
+                            {
+                                "Type": "Station",
+                                "GuideId": "s12345",
+                                "Title": "Radio Paradise",
+                                "Subtitle": "Commercial free",
+                                "Image": "http://example.com/radio-paradise.png",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+    monkeypatch.setattr("soundcork.bmx.urllib.request.urlopen", fake_urlopen)
+
+    response = tunein_search_v1("radio paradise")
+
+    assert " " not in requested_urls[0]
+    requested_query = urllib.parse.parse_qs(
+        urllib.parse.urlsplit(requested_urls[0]).query
+    )
+    assert requested_query["query"] == ["radio paradise"]
+
+    section_href = response.bmx_sections[0].links.self.href
+    decoded_section_uri = decode_navigate_href(section_href)
+    assert " " not in decoded_section_uri
+    decoded_query = urllib.parse.parse_qs(
+        urllib.parse.urlsplit(decoded_section_uri).query
+    )
+    assert decoded_query["query"] == ["radio paradise"]
+    assert response.bmx_sections[0].items[0].links.bmx_playback.href == (
+        "/v1/playback/station/s12345"
+    )


### PR DESCRIPTION
I noticed two issues with the Stockholm UI. When e.g. browsing in the TuneIn catalog the server responds with 500 Internal Server Error. Also the TuneIn search seems to not work if e.g. white space is used in the search term. I tried to fix this in this PR. The errors disappeared in my tests.