### PR TITLE
Fix empty preset item name

### DIFF
--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -242,8 +242,7 @@ class DataStore:
             created_on = preset.attrib.get("createdOn", "")
             updated_on = preset.attrib.get("updatedOn", "")
             content_item = preset.find("ContentItem")
-            # If name is not present, the .text will correctly raise an error here
-            name = content_item.find("itemName").text  # type: ignore
+            name = strip_element_text(content_item.find("itemName"))  # type: ignore
             source = content_item.attrib["source"]  # type: ignore
             type = content_item.attrib.get("type", "")  # type: ignore
             location = content_item.attrib.get("location", "")  # type: ignore

--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -242,7 +242,8 @@ class DataStore:
             created_on = preset.attrib.get("createdOn", "")
             updated_on = preset.attrib.get("updatedOn", "")
             content_item = preset.find("ContentItem")
-            name = strip_element_text(content_item.find("itemName"))  # type: ignore
+            # If name is not present, the .text will correctly raise an error here
+            name = content_item.find("itemName").text  # type: ignore
             source = content_item.attrib["source"]  # type: ignore
             type = content_item.attrib.get("type", "")  # type: ignore
             location = content_item.attrib.get("location", "")  # type: ignore

--- a/soundcork/marge.py
+++ b/soundcork/marge.py
@@ -94,10 +94,10 @@ def update_preset(
 
     # load the preset to add
 
-    name = strip_element_text(new_preset_elem.find("name"))
+    name = strip_element_text(new_preset_elem.find("name")) or strip_element_text(
+        new_preset_elem.find("username")
+    )
     source_id = strip_element_text(new_preset_elem.find("sourceid"))
-    # we could use username to match source maybe?
-    # username = new_preset_elem.find("username").text
     location = strip_element_text(new_preset_elem.find("location"))
     content_item_type = strip_element_text(new_preset_elem.find("contentItemType"))
 

--- a/soundcork/marge.py
+++ b/soundcork/marge.py
@@ -94,6 +94,9 @@ def update_preset(
 
     # load the preset to add
 
+    # 'name' and 'username' are the human-readable name of the preset, interchangeably.
+    # - Stockholm (the mobile app), when setting a preset, calls this field 'username'
+    # - The speakers themselves, when setting a preset, calls this field 'name'
     name = strip_element_text(new_preset_elem.find("name")) or strip_element_text(
         new_preset_elem.find("username")
     )

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -434,6 +434,51 @@ def test_get_presets_allows_empty_item_name(
     assert len(loaded) == 1
     assert loaded[0].name == ""
 
+
+def test_update_preset_uses_username_when_name_is_missing():
+    from soundcork.marge import update_preset
+
+    class PresetDatastore:
+        def __init__(self):
+            self.saved_presets = None
+
+        def get_configured_sources(self, account, device=""):
+            return [
+                ConfiguredSource(
+                    display_name="Internet Radio",
+                    id="100006",
+                    secret="",
+                    secret_type="",
+                    source_key_type="INTERNET_RADIO",
+                    source_key_account="",
+                    created_on=DEFAULT_DATESTR,
+                    updated_on=DEFAULT_DATESTR,
+                )
+            ]
+
+        def get_presets(self, account):
+            return []
+
+        def save_presets(self, account, device, presets_list):
+            self.saved_presets = presets_list
+
+    datastore = PresetDatastore()
+    xml = b'''<?xml version="1.0" encoding="UTF-8"?>
+        <preset buttonNumber="7">
+            <sourceid>100006</sourceid>
+            <username>Beats Radio</username>
+            <location>/v1/playback/station/s309907</location>
+            <contentItemType>stationurl</contentItemType>
+            <containerArt>http://cdn-profiles.tunein.com/s309907/images/logoq.jpg?t=638940914780000000</containerArt>
+        </preset>'''
+
+    response = update_preset(datastore, "2123456", "0000BA10B1AB", 7, xml)
+
+    assert datastore.saved_presets is not None
+    assert datastore.saved_presets[0].name == "Beats Radio"
+    assert response.find("name").text == "Beats Radio"
+    assert response.find("username").text == "Beats Radio"
+
 def test_get_recents_parses_xml_from_mocked_parse(
     datastore: DataStore,
     sample_device: DeviceInfo,

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -412,6 +412,28 @@ def test_get_presets_parses_xml_from_mocked_parse(
     assert loaded[1].container_art == ""
 
 
+def test_get_presets_allows_empty_item_name(
+    datastore: DataStore,
+    monkeypatch,
+):
+    xml = ET.fromstring("""
+        <presets>
+          <preset id="1" createdOn="" updatedOn="">
+            <ContentItem source="INTERNET_RADIO" type="uri" location="http://a" isPresetable="true">
+              <itemName />
+              <containerArt></containerArt>
+            </ContentItem>
+          </preset>
+        </presets>
+        """)
+    monkeypatch.setattr("soundcork.datastore.ET.parse", lambda _: ET.ElementTree(xml))
+    monkeypatch.setattr("soundcork.datastore.path.exists", lambda _: True)
+
+    loaded = datastore.get_presets("12345")
+
+    assert len(loaded) == 1
+    assert loaded[0].name == ""
+
 def test_get_recents_parses_xml_from_mocked_parse(
     datastore: DataStore,
     sample_device: DeviceInfo,

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -422,6 +422,7 @@ def test_get_presets_allows_empty_item_name(
             <ContentItem source="INTERNET_RADIO" type="uri" location="http://a" isPresetable="true">
               <itemName />
               <containerArt></containerArt>
+              <username>Beats Radio</username>
             </ContentItem>
           </preset>
         </presets>


### PR DESCRIPTION
When storing favorites with Stockholm the station is put into username field instead of the name field. Such malformed favorites lead to `500 Internal Server Error` because item name previously wasn't allowed to be empty.

## How to reproduce

1. Use Stockholm app and search for a radio station in TuneIn.
2. Drag and drop the station to the favorite sections below the six presets
3. The station is stored without name at all
4. Try to lookup presets and the soundcork responds with `500 Internal Server Error`

## Fix

We should resolve this in two ways

* We should use username as a fallback to avoid follow up issues like in validation crash with empty preset item name
* Treat empty preset `<itemName />` elements as empty strings when loading presets instead of passing None into the Preset model.
* This avoids a Pydantic validation crash when `/marge/streaming/account/{account}/presets/all` tries to return presets with empty item names.

Seems this is related to #292?