### PR TITLE
Add optional Spotify ZeroConf primer for cold-started speakers

### DIFF
--- a/docs/spotify.md
+++ b/docs/spotify.md
@@ -54,6 +54,24 @@ SPOTIFY_CLIENT_ID=your-client-id
 SPOTIFY_CLIENT_SECRET=your-client-secret
 ```
 
+Soundcork requests the minimal Spotify scope set needed for user identity and
+Web Playback SDK tokens by default:
+
+```bash
+SPOTIFY_SCOPES="streaming user-read-email user-read-private"
+```
+
+You can override `SPOTIFY_SCOPES` if your setup needs a broader Bose-like scope
+set:
+
+```bash
+SPOTIFY_SCOPES="streaming user-read-email user-read-private playlist-read-private playlist-read-collaborative user-library-read user-read-playback-state user-modify-playback-state user-read-currently-playing user-read-recently-played"
+```
+
+If you change `SPOTIFY_SCOPES` after linking an account, link the Spotify
+account again. Existing refresh tokens keep the scopes that were granted during
+their original OAuth flow.
+
 ### Step 3: Link Your Spotify Account
 
 **Note: in the future we will add a web UI for account management**
@@ -110,16 +128,41 @@ If you don't want to configure Spotify credentials in soundcork, you can manuall
 
 ### ZeroConf Primer (Cold Boot Activation)
 
-**NOTE because the automatic token refresh works in soundcork, thie ZeroConf Primer method has been disabled. The code is still available and the documentation is available here as a reference in case issues with the automatic token refresh are found during testing.**
+The ZeroConf primer is disabled by default. Enable it only if a cold-booted
+speaker can refresh Spotify tokens through Soundcork but still leaves Spotify
+presets stuck until you cast to the speaker once with Spotify Connect.
 
 On cold boot, the speaker does **not** request a Spotify token — it only fetches account data, source providers, and streaming tokens. Without an active Spotify session, presets fail silently.
 
 The ZeroConf primer solves this by proactively pushing a fresh Spotify access token to the speaker via the ZeroConf endpoint (port 8200). This is the same mechanism the Spotify desktop app uses when you cast to a speaker.
 
+Configuration:
+
+```bash
+SPOTIFY_ZEROCONF_PRIMER_ENABLED=true
+
+# Required allowlist. Values can be device IDs, IP addresses,
+# account/device pairs, or "*" to allow all known devices.
+SPOTIFY_ZEROCONF_PRIME_DEVICES="A0B1C2D3E4F5,192.168.1.25"
+
+# Backward-compatible alias also accepted:
+SOUNDCORK_SPOTIFY_PRIME_DEVICES="A0B1C2D3E4F5"
+
+# Default: 2700 seconds (45 minutes). Set to 0 to disable periodic priming
+# while keeping boot/new-speaker priming enabled.
+SPOTIFY_ZEROCONF_PRIMER_INTERVAL_SECONDS=2700
+```
+
 **When it runs:**
 - On speaker boot (`power_on` event), with retry/backoff (5s, 10s, 20s delays)
-- Periodically every 45 minutes (tokens expire after 1 hour)
-- When a new speaker is first seen via marge requests
+- Periodically at `SPOTIFY_ZEROCONF_PRIMER_INTERVAL_SECONDS` if the interval is greater than 0
+- When a new allowlisted speaker is first seen via marge requests
+
+**Gunicorn workers:** the primer registry and timer are in-process. The default
+configuration is safe because the primer is disabled and the allowlist is empty.
+If you enable the primer, prefer running Soundcork with a single Gunicorn worker
+for predictable behavior. With multiple workers, more than one worker may try to
+prime the same allowlisted speaker.
 
 **Boot sequence observed:**
 ```

--- a/soundcork/config.py
+++ b/soundcork/config.py
@@ -1,3 +1,4 @@
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -28,6 +29,25 @@ class Settings(BaseSettings):
     spotify_client_id: str = ""
     spotify_client_secret: str = ""
     spotify_redirect_uri: str = ""
+    spotify_scopes: str = "streaming user-read-email user-read-private"
+
+    # Spotify ZeroConf primer (optional, disabled by default)
+    spotify_zeroconf_primer_enabled: bool = False
+    spotify_zeroconf_prime_devices: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "spotify_zeroconf_prime_devices",
+            "SPOTIFY_ZEROCONF_PRIME_DEVICES",
+            "SOUNDCORK_SPOTIFY_PRIME_DEVICES",
+        ),
+    )
+    spotify_zeroconf_primer_interval_seconds: int = Field(
+        default=45 * 60,
+        validation_alias=AliasChoices(
+            "spotify_zeroconf_primer_interval_seconds",
+            "SPOTIFY_ZEROCONF_PRIMER_INTERVAL_SECONDS",
+        ),
+    )
 
     # (optional) local directory for soundcork to store detailed logs of 404 errors
     #  used for development/debugging

--- a/soundcork/main.py
+++ b/soundcork/main.py
@@ -70,6 +70,7 @@ from soundcork.model import (
 from soundcork.ui.speakers import Speakers
 from soundcork.unhandled_exception_handler import NotFoundHandler
 from soundcork.utils import strip_element_text
+from soundcork.zeroconf_primer import ZeroConfPrimer
 
 logging.basicConfig(
     level=logging.INFO,
@@ -83,7 +84,8 @@ speakers = Speakers(datastore, settings)
 
 from soundcork.spotify_service import SpotifyService
 
-spotify_service = SpotifyService()
+spotify_service = SpotifyService(settings)
+zeroconf_primer = ZeroConfPrimer(spotify_service, datastore, settings)
 
 
 description = """
@@ -105,12 +107,22 @@ tags_metadata = [
         "description": "Communicates with streaming radio services (eg. TuneIn).",
     },
 ]
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    zeroconf_primer.start_periodic()
+    yield
+    zeroconf_primer.stop_periodic()
+
+
 app = FastAPI(
     title="SoundCork",
     description=description,
     summary="Emulates SoundTouch servers.",
     version="0.0.1",
     openapi_tags=tags_metadata,
+    lifespan=lifespan,
 )
 
 from soundcork.management import router as management_router
@@ -133,6 +145,33 @@ app.include_router(management_router)
 
 
 startup_timestamp = int(datetime.now().timestamp() * 1000)
+
+
+@app.middleware("http")
+async def register_spotify_primer_speakers(request: Request, call_next):
+    response = await call_next(request)
+
+    if not zeroconf_primer.enabled:
+        return response
+
+    path = request.url.path
+    if "/marge/" not in path or "/account/" not in path or "/device/" not in path:
+        return response
+
+    parts = path.split("/")
+    try:
+        account_idx = parts.index("account") + 1
+        device_idx = parts.index("device") + 1
+        account_id = parts[account_idx]
+        device_id = parts[device_idx]
+    except (ValueError, IndexError):
+        return response
+
+    if not account_id or not device_id:
+        return response
+
+    zeroconf_primer.register_speaker(account_id, device_id)
+    return response
 
 
 @app.get("/")
@@ -160,6 +199,8 @@ async def power_on(request: Request, response: Response) -> Response:
     xml = await request.body()
     account = update_device_poweron(datastore, xml)
     if account:
+        source_ip = request.client.host if request.client else None
+        zeroconf_primer.on_power_on(source_ip)
         response.status_code = HTTPStatus.OK
         return response
     else:
@@ -903,7 +944,7 @@ app.include_router(get_groups_service_router(datastore))
 app.include_router(get_admin_router(datastore, speakers))
 
 #  include miniapp router
-app.include_router(get_miniapp_router(datastore, speakers))
+app.include_router(get_miniapp_router(datastore, speakers, zeroconf_primer))
 
 # 404 handling
 handler = NotFoundHandler(settings.unhandled_log_dir)

--- a/soundcork/management.py
+++ b/soundcork/management.py
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/mgmt", tags=["management"])
 
 datastore = DataStore()
 settings = Settings()
-spotify = SpotifyService()
+spotify = SpotifyService(settings)
 
 
 # --- Spotify ---

--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -19,6 +19,7 @@ from soundcork.ui.speakers import Speakers
 
 if TYPE_CHECKING:
     from soundcork.model import Preset
+    from soundcork.zeroconf_primer import ZeroConfPrimer
 
 logger = logging.getLogger(__name__)
 
@@ -57,10 +58,55 @@ def get_device_image(product_code: str) -> str:
     return DEVICE_IMAGE_MAP.get(product_code.lower(), DEFAULT_DEVICE_IMAGE)
 
 
-def get_miniapp_router(datastore: DataStore, speakers: Speakers):
+def get_miniapp_router(
+    datastore: DataStore,
+    speakers: Speakers,
+    zeroconf_primer: "ZeroConfPrimer | None" = None,
+):
     templates = Jinja2Templates(directory="templates")
 
     router = APIRouter(tags=["miniapp"])
+
+    def prime_spotify_before_play(
+        account_id: str | None,
+        device_id: str | None,
+        content_item_id: str | None,
+    ) -> None:
+        if not (
+            zeroconf_primer
+            and zeroconf_primer.enabled
+            and account_id
+            and device_id
+            and content_item_id
+        ):
+            return
+
+        try:
+            content_item = datastore.get_content_item(
+                account=account_id,
+                device_id=device_id,
+                ci_id=content_item_id,
+            )
+        except Exception:
+            logger.exception(
+                "Could not inspect content item %s before playback",
+                content_item_id,
+            )
+            return
+
+        if not content_item or (content_item.source or "").upper() != "SPOTIFY":
+            return
+
+        try:
+            zeroconf_primer.prime_before_play(
+                device_id,
+                account_id=account_id,
+            )
+        except Exception:
+            logger.exception(
+                "Spotify ZeroConf pre-play priming failed for device %s",
+                device_id,
+            )
 
     @router.get("/miniapp", response_class=HTMLResponse)
     async def main_page(request: Request):
@@ -382,6 +428,12 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             if not selected_content_item_id or not selected_device_id:
                 logger.warning("Cannot play: content_item or device not selected")
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+
+            account_id = request.cookies.get("soundcork_account_id")
+
+            prime_spotify_before_play(
+                account_id, selected_device_id, selected_content_item_id
+            )
 
             # Play the content_item
             if speakers.play_content_item(selected_device_id, selected_content_item_id):

--- a/soundcork/spotify_service.py
+++ b/soundcork/spotify_service.py
@@ -28,10 +28,9 @@ SPOTIFY_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
 SPOTIFY_TOKEN_URL = "https://accounts.spotify.com/api/token"
 SPOTIFY_API_BASE = "https://api.spotify.com/v1"
 
-# Scopes needed for user profile and entity resolution.
-# Add "streaming" and "user-modify-playback-state" if you plan to
-# control playback via the Spotify Web API.
-SPOTIFY_SCOPES = "user-read-private user-read-email"
+# Scopes needed for user profile, entity resolution, and Web Playback SDK tokens.
+SPOTIFY_SCOPES_MINIMAL = "streaming user-read-email user-read-private"
+SPOTIFY_SCOPES = SPOTIFY_SCOPES_MINIMAL
 
 # full set of permissions that bose returned; included in case they're
 # needed in the future (like for browse)
@@ -45,11 +44,15 @@ SPOTIFY_SCOPES_FULL = (
 class SpotifyService:
     """TODO refactor so instead of writing to disk, it relies on either the datastore or storing in memory."""
 
-    def __init__(self):
-        self._settings = Settings()
+    def __init__(self, settings: Settings | None = None):
+        self._settings = settings or Settings()
         self._accounts_file = os.path.join(
             self._settings.data_dir, "spotify", "accounts.json"
         )
+
+    @property
+    def spotify_scopes(self) -> str:
+        return self._settings.spotify_scopes or SPOTIFY_SCOPES_MINIMAL
 
     def _ensure_spotify_dir(self):
         """Create the spotify data directory if it doesn't exist.
@@ -87,7 +90,7 @@ class SpotifyService:
             "client_id": self._settings.spotify_client_id,
             "response_type": "code",
             "redirect_uri": redirect_uri or self._settings.spotify_redirect_uri,
-            "scope": SPOTIFY_SCOPES,
+            "scope": self.spotify_scopes,
         }
         return f"{SPOTIFY_AUTHORIZE_URL}?{urllib.parse.urlencode(params)}"
 
@@ -118,6 +121,7 @@ class SpotifyService:
             "accessToken": access_token,
             "refreshToken": refresh_token,
             "tokenExpiresAt": int(time.time()) + expires_in,
+            "scope": token_data.get("scope", self.spotify_scopes),
         }
 
         # Upsert: replace if same user ID already exists
@@ -195,13 +199,16 @@ class SpotifyService:
             account["tokenExpiresAt"] = now + token_data.get("expires_in", 3600)
             if "refresh_token" in token_data:
                 account["refreshToken"] = token_data["refresh_token"]
+            account["scope"] = token_data.get(
+                "scope", account.get("scope", self.spotify_scopes)
+            )
             self._save_accounts(accounts)
 
         return {
             "access_token": account["accessToken"],
             "token_type": "Bearer",
             "expires_in": account["tokenExpiresAt"] - now,
-            "scope": SPOTIFY_SCOPES,
+            "scope": account.get("scope", self.spotify_scopes),
         }
 
     def get_fresh_token_sync(self) -> dict:
@@ -209,7 +216,9 @@ class SpotifyService:
 
     def get_spotify_user_id(self) -> str:
         accounts = self._load_accounts()
-        return accounts[0].get("id", "")
+        if not accounts:
+            return ""
+        return accounts[0].get("spotifyUserId") or accounts[0].get("id", "")
 
     async def _get_user_profile(self, access_token: str) -> dict:
         """Fetch the current user's Spotify profile."""

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -13,6 +13,9 @@ DEVICE_ID = "device-1"
 
 
 class FakeDatastore:
+    def __init__(self, content_source: str = "LOCAL_INTERNET_RADIO") -> None:
+        self.content_source = content_source
+
     def account_exists(self, account_id: str) -> bool:
         return account_id == ACCOUNT_ID
 
@@ -35,6 +38,11 @@ class FakeDatastore:
             product_code="SoundTouch10",
             device_id=DEVICE_ID,
         )
+
+    def get_content_item(self, account: str, device_id: str, ci_id: str):
+        assert account == ACCOUNT_ID
+        assert device_id == DEVICE_ID
+        return SimpleNamespace(source=self.content_source)
 
     def get_presets(self, account_id: str) -> list[Preset]:
         assert account_id == ACCOUNT_ID
@@ -70,12 +78,37 @@ class FakeSpeakers:
         return self.play_result
 
 
-def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
+class FakePrimer:
+    enabled = True
+
+    def __init__(self) -> None:
+        self.prime_calls: list[tuple[str, str | None, bool, float]] = []
+
+    def prime_before_play(
+        self,
+        device_id: str,
+        account_id: str | None = None,
+        force: bool = True,
+        wait_seconds: float = 1.0,
+    ) -> bool:
+        self.prime_calls.append((device_id, account_id, force, wait_seconds))
+        return False
+
+
+def make_client(
+    monkeypatch,
+    speakers: FakeSpeakers | None = None,
+    datastore: FakeDatastore | None = None,
+    primer: FakePrimer | None = None,
+):
     monkeypatch.chdir(Path(__file__).resolve().parents[1])
     app = FastAPI()
     fake_speakers = speakers or FakeSpeakers()
+    fake_datastore = datastore or FakeDatastore()
     app.include_router(
-        get_miniapp_router(cast(Any, FakeDatastore()), cast(Any, fake_speakers))
+        get_miniapp_router(
+            cast(Any, fake_datastore), cast(Any, fake_speakers), cast(Any, primer)
+        )
     )
     return TestClient(app), fake_speakers
 
@@ -99,3 +132,43 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
 
     assert response.status_code == 200
     assert "Účet ložnice" in response.text
+
+
+def test_play_primes_spotify_before_playback_when_primer_configured(monkeypatch):
+    primer = FakePrimer()
+    client, speakers = make_client(
+        monkeypatch,
+        datastore=FakeDatastore("SPOTIFY"),
+        primer=primer,
+    )
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        "/miniapp/play?selected_device_id=device-1&selected_content_item_id=content-1",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert "selected_device_id=device-1" in response.headers["location"]
+    assert "selected_content_item_id=content-1" in response.headers["location"]
+    assert primer.prime_calls == [(DEVICE_ID, ACCOUNT_ID, True, 1.0)]
+    assert speakers.play_calls == [(DEVICE_ID, "content-1")]
+
+
+def test_play_does_not_prime_non_spotify_content(monkeypatch):
+    primer = FakePrimer()
+    client, speakers = make_client(
+        monkeypatch,
+        datastore=FakeDatastore("LOCAL_INTERNET_RADIO"),
+        primer=primer,
+    )
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        "/miniapp/play?selected_device_id=device-1&selected_content_item_id=content-1",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert primer.prime_calls == []
+    assert speakers.play_calls == [(DEVICE_ID, "content-1")]

--- a/soundcork/tests/test_spotify_service.py
+++ b/soundcork/tests/test_spotify_service.py
@@ -1,0 +1,56 @@
+import json
+import urllib.parse
+
+from soundcork.config import Settings
+from soundcork.spotify_service import SpotifyService
+
+
+def test_authorize_url_uses_minimal_streaming_scope(tmp_path):
+    settings = Settings(
+        data_dir=str(tmp_path),
+        spotify_client_id="client-id",
+        spotify_client_secret="client-secret",
+        spotify_redirect_uri="https://soundcork.example/mgmt/spotify/callback",
+    )
+    service = SpotifyService(settings)
+
+    authorize_url = service.build_authorize_url()
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(authorize_url).query)
+
+    assert query["scope"] == ["streaming user-read-email user-read-private"]
+
+
+def test_authorize_url_uses_configured_scope_override(tmp_path):
+    settings = Settings(
+        data_dir=str(tmp_path),
+        spotify_client_id="client-id",
+        spotify_client_secret="client-secret",
+        spotify_redirect_uri="https://soundcork.example/mgmt/spotify/callback",
+        spotify_scopes="streaming user-read-private user-read-email user-modify-playback-state",
+    )
+    service = SpotifyService(settings)
+
+    authorize_url = service.build_authorize_url()
+    query = urllib.parse.parse_qs(urllib.parse.urlsplit(authorize_url).query)
+
+    assert query["scope"] == [
+        "streaming user-read-private user-read-email user-modify-playback-state"
+    ]
+
+
+def test_get_spotify_user_id_reads_stored_spotify_user_id(tmp_path):
+    spotify_dir = tmp_path / "spotify"
+    spotify_dir.mkdir()
+    (spotify_dir / "accounts.json").write_text(
+        json.dumps([{"id": "wrong-key", "spotifyUserId": "mr.tao"}])
+    )
+
+    service = SpotifyService(Settings(data_dir=str(tmp_path)))
+
+    assert service.get_spotify_user_id() == "mr.tao"
+
+
+def test_get_spotify_user_id_returns_empty_string_without_accounts(tmp_path):
+    service = SpotifyService(Settings(data_dir=str(tmp_path)))
+
+    assert service.get_spotify_user_id() == ""

--- a/soundcork/tests/test_zeroconf_primer.py
+++ b/soundcork/tests/test_zeroconf_primer.py
@@ -1,0 +1,219 @@
+import json
+import urllib.parse
+from types import SimpleNamespace
+from typing import Any
+
+from soundcork.config import Settings
+from soundcork.zeroconf_primer import TrackedSpeaker, ZeroConfPrimer
+
+
+class FakeSpotify:
+    def get_spotify_user_id(self) -> str:
+        return "mr.tao"
+
+    def get_fresh_token_sync(self) -> dict:
+        return {"access_token": "access-token", "expires_in": 3600}
+
+
+class FakeDatastore:
+    def list_accounts(self) -> list[str]:
+        return ["12345"]
+
+    def list_devices(self, account_id: str) -> list[str]:
+        return ["device-1"]
+
+    def get_device_info(self, account_id: str, device_id: str):
+        return SimpleNamespace(ip_address="10.0.0.20")
+
+
+def settings(**overrides: Any) -> Settings:
+    values: dict[str, Any] = {
+        "spotify_client_id": "client-id",
+        "spotify_client_secret": "client-secret",
+        "spotify_zeroconf_primer_enabled": True,
+        "spotify_zeroconf_prime_devices": "device-1",
+    }
+    values.update(overrides)
+    return Settings(**values)
+
+
+def test_soundcork_prime_devices_alias_is_supported(monkeypatch):
+    monkeypatch.setenv("SOUNDCORK_SPOTIFY_PRIME_DEVICES", "device-1")
+
+    loaded = Settings(_env_file=None)
+
+    assert loaded.spotify_zeroconf_prime_devices == "device-1"
+
+
+def test_primer_interval_env_var_is_supported(monkeypatch):
+    monkeypatch.setenv("SPOTIFY_ZEROCONF_PRIMER_INTERVAL_SECONDS", "123")
+
+    loaded = Settings(_env_file=None)
+
+    assert loaded.spotify_zeroconf_primer_interval_seconds == 123
+
+
+def test_speaker_allowlist_accepts_device_id_ip_or_account_device():
+    primer = ZeroConfPrimer(FakeSpotify(), FakeDatastore(), settings())
+
+    assert primer._speaker_allowed(TrackedSpeaker("12345", "device-1", "10.0.0.99"))
+
+    primer = ZeroConfPrimer(
+        FakeSpotify(),
+        FakeDatastore(),
+        settings(spotify_zeroconf_prime_devices="10.0.0.20"),
+    )
+    assert primer._speaker_allowed(TrackedSpeaker("12345", "other", "10.0.0.20"))
+
+    primer = ZeroConfPrimer(
+        FakeSpotify(),
+        FakeDatastore(),
+        settings(spotify_zeroconf_prime_devices="12345/device-2"),
+    )
+    assert primer._speaker_allowed(TrackedSpeaker("12345", "device-2", "10.0.0.21"))
+
+
+def test_empty_allowlist_prevents_priming_without_network(monkeypatch):
+    primer = ZeroConfPrimer(
+        FakeSpotify(),
+        FakeDatastore(),
+        settings(spotify_zeroconf_prime_devices=""),
+    )
+    speaker = TrackedSpeaker("12345", "device-1", "10.0.0.20")
+
+    def fail_send_add_user(*_):
+        raise AssertionError("network should not be called without an allowlist")
+
+    monkeypatch.setattr(
+        ZeroConfPrimer, "_send_add_user", staticmethod(fail_send_add_user)
+    )
+
+    assert primer._prime_if_needed(speaker) is False
+
+
+def test_prime_if_needed_sends_add_user_for_allowlisted_speaker(monkeypatch):
+    primer = ZeroConfPrimer(FakeSpotify(), FakeDatastore(), settings())
+    speaker = TrackedSpeaker("12345", "device-1", "10.0.0.20")
+    active_users = ["", "mr.tao"]
+    sent = {}
+
+    def get_active_user(_speaker_ip):
+        return active_users.pop(0)
+
+    def send_add_user(speaker_ip, user_id, token):
+        sent["speaker_ip"] = speaker_ip
+        sent["user_id"] = user_id
+        sent["token"] = token
+        return {"status": 101}
+
+    monkeypatch.setattr(
+        ZeroConfPrimer, "_get_active_user", staticmethod(get_active_user)
+    )
+    monkeypatch.setattr(ZeroConfPrimer, "_send_add_user", staticmethod(send_add_user))
+    monkeypatch.setattr("soundcork.zeroconf_primer.time.sleep", lambda _: None)
+
+    assert primer._prime_if_needed(speaker) is True
+    assert sent == {
+        "speaker_ip": "10.0.0.20",
+        "user_id": "mr.tao",
+        "token": "access-token",
+    }
+    assert speaker.prime_failures == 0
+    assert speaker.last_primed > 0
+
+
+def test_prime_if_needed_skips_when_active_user_exists(monkeypatch):
+    primer = ZeroConfPrimer(FakeSpotify(), FakeDatastore(), settings())
+    speaker = TrackedSpeaker("12345", "device-1", "10.0.0.20")
+
+    def fail_send_add_user(*_):
+        raise AssertionError("addUser should not be sent when activeUser exists")
+
+    monkeypatch.setattr(
+        ZeroConfPrimer,
+        "_get_active_user",
+        staticmethod(lambda _speaker_ip: "other-user"),
+    )
+    monkeypatch.setattr(
+        ZeroConfPrimer, "_send_add_user", staticmethod(fail_send_add_user)
+    )
+
+    assert primer._prime_if_needed(speaker) is True
+    assert speaker.prime_failures == 0
+    assert speaker.last_primed > 0
+
+
+def test_prime_before_play_forces_add_user_for_other_active_user(monkeypatch):
+    primer = ZeroConfPrimer(FakeSpotify(), FakeDatastore(), settings())
+    sent = {}
+
+    def send_add_user(speaker_ip, user_id, token):
+        sent["speaker_ip"] = speaker_ip
+        sent["user_id"] = user_id
+        sent["token"] = token
+        return {"status": 101}
+
+    monkeypatch.setattr(
+        ZeroConfPrimer,
+        "_get_active_user",
+        staticmethod(lambda _speaker_ip: "other-user"),
+    )
+    monkeypatch.setattr(ZeroConfPrimer, "_send_add_user", staticmethod(send_add_user))
+    monkeypatch.setattr("soundcork.zeroconf_primer.time.sleep", lambda _: None)
+
+    assert primer.prime_before_play("device-1", account_id="12345") is True
+    assert sent == {
+        "speaker_ip": "10.0.0.20",
+        "user_id": "mr.tao",
+        "token": "access-token",
+    }
+    assert primer._speakers["device-1"].ip_address == "10.0.0.20"
+
+
+def test_send_add_user_posts_expected_zeroconf_payload(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_):
+            return False
+
+        def read(self):
+            return json.dumps({"status": 101}).encode()
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["body"] = request.data.decode()
+        captured["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        "soundcork.zeroconf_primer.urllib.request.urlopen", fake_urlopen
+    )
+
+    result = ZeroConfPrimer._send_add_user("10.0.0.20", "mr.tao", "access-token")
+    body = urllib.parse.parse_qs(captured["body"])
+
+    assert result == {"status": 101}
+    assert captured["url"] == "http://10.0.0.20:8200/zc"
+    assert captured["timeout"] == 10
+    assert body == {
+        "action": ["addUser"],
+        "userName": ["mr.tao"],
+        "blob": ["access-token"],
+        "tokenType": ["accesstoken"],
+    }
+
+
+def test_periodic_primer_does_not_start_without_allowlist():
+    primer = ZeroConfPrimer(
+        FakeSpotify(),
+        FakeDatastore(),
+        settings(spotify_zeroconf_prime_devices=""),
+    )
+
+    primer.start_periodic()
+
+    assert primer._timer is None

--- a/soundcork/zeroconf_primer.py
+++ b/soundcork/zeroconf_primer.py
@@ -1,83 +1,29 @@
-"""This feature is currently disabled because all the spotify
-functionality is available just through the oauth endpoint.
-Keeping this implementation for reference in case some deficiency
-is found in the oauth endpoint implementation during user testing.
-
-To re-enable add the following to main.py:
-
-from soundcork.zeroconf_primer import ZeroConfPrimer
-
-zeroconf_primer = ZeroConfPrimer(spotify_service, datastore, settings)
-
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-   logger.info("Starting up soundcork -- zeroconf configuration")
-   zeroconf_primer.start_periodic()
-   logger.info("done starting up server")
-   yield
-   zeroconf_primer.stop_periodic()
-   logger.debug("closing server")
-
-
-@app.middleware("http")
-async def register_speakers_middleware(request: Request, call_next):
-#   Capture account/device IDs from marge URLs for the Spotify primer.
-   response = await call_next(request)
-
-   path = request.url.path
-   if "/marge/" in path and "/account/" in path and "/device/" in path:
-       parts = path.split("/")
-       try:
-           acc_idx = parts.index("account") + 1
-           dev_idx = parts.index("device") + 1
-           if acc_idx < len(parts) and dev_idx < len(parts):
-               zeroconf_primer.register_speaker(parts[acc_idx], parts[dev_idx])
-       except (ValueError, IndexError):
-           pass
-
-   return response
-
-(add lifespan method to FastAPI creation, like)
-app = FastAPI(
-    title="SoundCork",
-    description=description,
-    summary="Emulates SoundTouch servers.",
-    version="0.0.1",
-    openapi_tags=tags_metadata,
-    lifespan=lifespan,
-)
-
-(in power_on)
-        # Prime speakers for Spotify after boot.  The primer handles
-        # retry/backoff in a background thread so the response is fast.
-        zeroconf_primer.on_power_on(source_ip)
-
-"""
-
 """Spotify ZeroConf primer for SoundTouch speakers.
 
-After Bose's cloud servers shut down, speakers can no longer obtain
-Spotify credentials via the marge /full account response.  Instead,
-we prime speakers by sending a valid Spotify access token directly
-to their ZeroConf endpoint (port 8200) using the addUser action.
+After Bose's cloud servers shut down, some SoundTouch speakers no longer request
+a Spotify OAuth token during cold boot.  They can remain unable to play Spotify
+presets until a Spotify Connect client sets the speaker's active user via the
+local ZeroConf endpoint.
 
-This is the same mechanism the Spotify desktop app uses: a plain
-access token is sent as the blob parameter (no DH encryption).
+This is the same mechanism the Spotify desktop app uses: a plain access token
+is sent as the blob parameter (no DH encryption).
 
-Speakers are tracked dynamically: when a speaker contacts any marge
-endpoint, its account/device ID is captured and its IP is looked up
-from the datastore.  This avoids the need to scan directories and
-ensures newly added speakers are primed automatically.
+Speakers are tracked dynamically: when a speaker contacts any marge endpoint,
+its account/device ID is captured and its IP is looked up from the datastore.
+The registry is also seeded from the datastore on startup and after speaker boot
+events.
 
 The primer runs:
   - On speaker boot (triggered by the power_on endpoint), with retry
-  - When a new speaker is seen for the first time
-  - Periodically to keep sessions alive before tokens expire (1 hour)
+  - When a new allowlisted speaker is seen for the first time
+  - Periodically at the configured interval
+  - Immediately before Miniapp playback, forcing addUser for that target speaker
 
 Configuration:
   - SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET must be set
   - A Spotify account must be linked via the management API
   - Speaker IP addresses are read from the datastore (DeviceInfo)
+  - SPOTIFY_ZEROCONF_PRIME_DEVICES must explicitly allow devices
 """
 
 import json
@@ -86,7 +32,7 @@ import threading
 import time
 import urllib.parse
 import urllib.request
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
@@ -95,7 +41,6 @@ from soundcork.spotify_service import SpotifyService
 logger = logging.getLogger(__name__)
 
 ZEROCONF_PORT = 8200
-PERIODIC_CHECK_SECONDS = 45 * 60  # 45 minutes
 BOOT_RETRY_DELAYS = [5, 10, 20]  # seconds between retries after power_on
 MAX_CONSECUTIVE_FAILURES = 5  # remove speaker from registry after this many
 
@@ -127,15 +72,19 @@ class ZeroConfPrimer:
         self._cached_token: str | None = None
         self._token_expires_at: float = 0.0
 
+    @property
+    def enabled(self) -> bool:
+        return self._settings.spotify_zeroconf_primer_enabled
+
     # --- Speaker registration ---
 
     def register_speaker(self, account_id: str, device_id: str):
         """Register a speaker that contacted a marge endpoint.
 
-        Called from marge request handlers.  If this is a new speaker,
-        resolves its IP and primes it in the background.
+        Called from marge request handlers.  If this is a new allowlisted
+        speaker, resolves its IP and primes it in the background.
         """
-        if not self._settings.spotify_client_id:
+        if not self._can_prime():
             return
 
         is_new = False
@@ -149,55 +98,103 @@ class ZeroConfPrimer:
                 )
                 is_new = True
                 logger.info(
-                    "New speaker registered: %s (account=%s, ip=%s)",
+                    "New speaker registered for Spotify primer: %s (account=%s, ip=%s)",
                     device_id,
                     account_id,
                     ip,
                 )
             else:
+                speaker = self._speakers[device_id]
                 # Update account_id in case it changed
-                self._speakers[device_id].account_id = account_id
+                speaker.account_id = account_id
+                if not speaker.ip_address:
+                    speaker.ip_address = self._resolve_speaker_ip(account_id, device_id)
 
-        if is_new:
             speaker = self._speakers[device_id]
-            if speaker.ip_address:
-                threading.Thread(
-                    target=self._prime_if_needed,
-                    args=(speaker,),
-                    daemon=True,
-                ).start()
+
+        if is_new and speaker.ip_address and self._speaker_allowed(speaker):
+            threading.Thread(
+                target=self._prime_if_needed,
+                args=(speaker,),
+                daemon=True,
+                name="spotify-zeroconf-prime",
+            ).start()
 
     def on_power_on(self, source_ip: str | None = None):
         """Called when a speaker sends power_on.
 
-        Primes all known speakers with retry/backoff, since the
+        Primes known allowlisted speakers with retry/backoff, since the
         speaker's ZeroConf port may not be ready immediately.
         If no speakers are registered yet, discovers from datastore.
         """
-        if not self._settings.spotify_client_id:
+        if not self._can_prime():
             return
 
         threading.Thread(
             target=self._power_on_prime,
             args=(source_ip,),
             daemon=True,
+            name="spotify-zeroconf-power-on",
         ).start()
+
+    def prime_before_play(
+        self,
+        device_id: str,
+        account_id: str | None = None,
+        force: bool = True,
+        wait_seconds: float = 1.0,
+    ) -> bool:
+        """Synchronously prime a target speaker before Miniapp playback.
+
+        This path intentionally defaults to forcing addUser so playback can
+        recover when another Spotify account is currently the speaker's
+        activeUser.  Background boot and periodic priming still use
+        _prime_if_needed and keep their activeUser skip behavior.
+        """
+        if not self._can_prime():
+            return False
+
+        speaker = self._get_or_register_speaker(device_id, account_id)
+        if not speaker:
+            logger.debug(
+                "Could not find speaker %s for Spotify pre-play primer", device_id
+            )
+            return False
+
+        if force:
+            return self._prime_speaker(speaker, wait_seconds=wait_seconds)
+        return self._prime_if_needed(speaker)
 
     # --- Periodic ---
 
     def start_periodic(self):
-        """Start the periodic re-prime background task."""
-        if not self._settings.spotify_client_id:
-            logger.info("Spotify not configured — periodic primer disabled")
+        """Start the periodic re-prime background task if configured."""
+        if not self.enabled:
+            logger.info("Spotify ZeroConf primer disabled")
+            return
+        if (
+            not self._settings.spotify_client_id
+            or not self._settings.spotify_client_secret
+        ):
+            logger.info("Spotify not configured; ZeroConf primer disabled")
+            return
+        if not self._allowed_devices():
+            logger.warning(
+                "Spotify ZeroConf primer enabled without an allowlist; no speakers will be primed"
+            )
+            return
+
+        interval = self._periodic_interval_seconds()
+        if interval <= 0:
+            logger.info("Spotify ZeroConf periodic primer disabled by interval")
             return
 
         # Seed the registry from the datastore on startup
         self._seed_from_datastore()
-
         self._schedule_next()
         logger.info(
-            "Periodic Spotify primer started (every %d minutes)",
-            PERIODIC_CHECK_SECONDS // 60,
+            "Periodic Spotify ZeroConf primer started (every %d seconds)",
+            interval,
         )
 
     def stop_periodic(self):
@@ -208,40 +205,120 @@ class ZeroConfPrimer:
 
     # --- Internal ---
 
+    def _is_configured(self) -> bool:
+        return bool(
+            self.enabled
+            and self._settings.spotify_client_id
+            and self._settings.spotify_client_secret
+        )
+
+    def _can_prime(self) -> bool:
+        return self._is_configured() and bool(self._allowed_devices())
+
+    def _allowed_devices(self) -> set[str]:
+        return {
+            device.strip().lower()
+            for device in self._settings.spotify_zeroconf_prime_devices.split(",")
+            if device.strip()
+        }
+
+    def _speaker_allowed(self, speaker: TrackedSpeaker) -> bool:
+        allowed_devices = self._allowed_devices()
+        if not allowed_devices:
+            return False
+        if "*" in allowed_devices:
+            return True
+
+        speaker_keys = {
+            speaker.device_id.lower(),
+            f"{speaker.account_id}/{speaker.device_id}".lower(),
+        }
+        if speaker.ip_address:
+            speaker_keys.add(speaker.ip_address.lower())
+
+        return bool(speaker_keys & allowed_devices)
+
+    def _get_or_register_speaker(
+        self, device_id: str, account_id: str | None
+    ) -> TrackedSpeaker | None:
+        """Return a tracked speaker, resolving it from the datastore if needed."""
+        if not device_id:
+            return None
+
+        with self._lock:
+            speaker = self._speakers.get(device_id)
+
+        if not speaker and not account_id:
+            self._seed_from_datastore()
+            with self._lock:
+                speaker = self._speakers.get(device_id)
+
+        if not speaker and account_id:
+            ip = self._resolve_speaker_ip(account_id, device_id)
+            speaker = TrackedSpeaker(account_id, device_id, ip)
+            with self._lock:
+                self._speakers[device_id] = speaker
+            logger.info(
+                "Speaker registered for Spotify pre-play primer: %s (account=%s, ip=%s)",
+                device_id,
+                account_id,
+                ip,
+            )
+
+        if speaker and account_id:
+            speaker.account_id = account_id
+
+        if speaker and not speaker.ip_address and speaker.account_id:
+            speaker.ip_address = self._resolve_speaker_ip(
+                speaker.account_id, speaker.device_id
+            )
+
+        if speaker and not self._speaker_allowed(speaker):
+            logger.debug(
+                "Speaker %s is not allowlisted for Spotify pre-play primer",
+                speaker.device_id,
+            )
+            return None
+
+        return speaker
+
+    def _periodic_interval_seconds(self) -> int:
+        return self._settings.spotify_zeroconf_primer_interval_seconds
+
     def _seed_from_datastore(self):
         """Populate the speaker registry from the datastore on startup."""
-        import os
-
-        data_dir = self._settings.data_dir
-        if not data_dir or not os.path.isdir(data_dir):
+        try:
+            account_ids = self._datastore.list_accounts()
+        except (FileNotFoundError, StopIteration):
+            logger.debug("Could not list accounts while seeding Spotify primer")
             return
 
-        for account_id in os.listdir(data_dir):
-            account_path = os.path.join(data_dir, account_id)
-            if not os.path.isdir(account_path):
+        for account_id in account_ids:
+            if not account_id:
                 continue
 
             try:
                 device_ids = self._datastore.list_devices(account_id)
-            except (StopIteration, FileNotFoundError):
+            except (FileNotFoundError, StopIteration):
                 continue
 
             for device_id in device_ids:
                 if not device_id:
                     continue
                 ip = self._resolve_speaker_ip(account_id, device_id)
-                if ip:
-                    with self._lock:
-                        if device_id not in self._speakers:
-                            self._speakers[device_id] = TrackedSpeaker(
-                                account_id=account_id,
-                                device_id=device_id,
-                                ip_address=ip,
-                            )
+                if not ip:
+                    continue
+                with self._lock:
+                    if device_id not in self._speakers:
+                        self._speakers[device_id] = TrackedSpeaker(
+                            account_id=account_id,
+                            device_id=device_id,
+                            ip_address=ip,
+                        )
 
         count = len(self._speakers)
         if count:
-            logger.info("Seeded %d speaker(s) from datastore", count)
+            logger.info("Seeded %d speaker(s) for Spotify ZeroConf primer", count)
 
     def _resolve_speaker_ip(self, account_id: str, device_id: str) -> str | None:
         """Look up a speaker's IP address from the datastore."""
@@ -275,12 +352,12 @@ class ZeroConfPrimer:
             return None
 
         self._cached_token = token
-        self._token_expires_at = now + 3600  # tokens last 1 hour
+        self._token_expires_at = now + int(token_dict.get("expires_in", 3600))
         return token, user_id
 
     def _prime_if_needed(self, speaker: TrackedSpeaker) -> bool:
         """Check activeUser and prime only if empty."""
-        if not speaker.ip_address:
+        if not speaker.ip_address or not self._speaker_allowed(speaker):
             return False
 
         try:
@@ -292,15 +369,18 @@ class ZeroConfPrimer:
                     active_user,
                 )
                 speaker.last_primed = time.time()
+                speaker.prime_failures = 0
                 return True
         except Exception:
             logger.debug("Could not check activeUser for %s", speaker.ip_address)
 
         return self._prime_speaker(speaker)
 
-    def _prime_speaker(self, speaker: TrackedSpeaker) -> bool:
+    def _prime_speaker(
+        self, speaker: TrackedSpeaker, wait_seconds: float = 2.0
+    ) -> bool:
         """Send addUser to a speaker."""
-        if not speaker.ip_address:
+        if not speaker.ip_address or not self._speaker_allowed(speaker):
             return False
 
         creds = self._get_token()
@@ -324,7 +404,7 @@ class ZeroConfPrimer:
             logger.info("addUser accepted by %s (status 101)", speaker.ip_address)
 
             # Verify activeUser was set
-            time.sleep(2)
+            time.sleep(wait_seconds)
             active_user = self._get_active_user(speaker.ip_address)
             if active_user:
                 logger.info(
@@ -335,13 +415,13 @@ class ZeroConfPrimer:
                 speaker.last_primed = time.time()
                 speaker.prime_failures = 0
                 return True
-            else:
-                logger.warning(
-                    "Speaker %s returned 101 but activeUser still empty",
-                    speaker.ip_address,
-                )
-                speaker.prime_failures += 1
-                return False
+
+            logger.warning(
+                "Speaker %s returned 101 but activeUser still empty",
+                speaker.ip_address,
+            )
+            speaker.prime_failures += 1
+            return False
 
         except Exception:
             logger.exception("Failed to prime speaker %s", speaker.ip_address)
@@ -350,16 +430,28 @@ class ZeroConfPrimer:
 
     def _power_on_prime(self, source_ip: str | None):
         """Prime speakers after boot with retry/backoff."""
+        self._seed_from_datastore()
         with self._lock:
-            speakers = list(self._speakers.values())
+            speakers = [
+                speaker
+                for speaker in self._speakers.values()
+                if self._speaker_allowed(speaker)
+            ]
+
+        if source_ip:
+            source_speakers = [
+                speaker for speaker in speakers if speaker.ip_address == source_ip
+            ]
+            if source_speakers:
+                speakers = source_speakers
 
         if not speakers:
-            logger.info("No speakers registered — nothing to prime")
+            logger.info("No allowlisted speakers registered for Spotify primer")
             return
 
         for delay in BOOT_RETRY_DELAYS:
             logger.info(
-                "Speaker booted — waiting %ds before priming %d speaker(s)...",
+                "Speaker booted; waiting %ds before priming %d speaker(s)",
                 delay,
                 len(speakers),
             )
@@ -367,29 +459,34 @@ class ZeroConfPrimer:
 
             all_ok = True
             for speaker in speakers:
-                if not speaker.ip_address:
-                    continue
                 if not self._prime_if_needed(speaker):
                     all_ok = False
 
             if all_ok:
-                logger.info("All speakers primed successfully")
+                logger.info("All allowlisted speakers primed successfully")
                 return
 
-        logger.warning("Some speakers failed to prime after all retries")
+        logger.warning("Some allowlisted speakers failed to prime after all retries")
 
     def _schedule_next(self):
         """Schedule the next periodic check."""
-        self._timer = threading.Timer(PERIODIC_CHECK_SECONDS, self._periodic_tick)
+        interval = self._periodic_interval_seconds()
+        if interval <= 0:
+            return
+        self._timer = threading.Timer(interval, self._periodic_tick)
         self._timer.daemon = True
         self._timer.start()
 
     def _periodic_tick(self):
-        """Periodic task: check and re-prime all speakers if needed."""
+        """Periodic task: check and re-prime all allowlisted speakers if needed."""
         try:
-            logger.info("Periodic Spotify primer check running...")
+            logger.info("Periodic Spotify ZeroConf primer check running")
             with self._lock:
-                speakers = list(self._speakers.values())
+                speakers = [
+                    speaker
+                    for speaker in self._speakers.values()
+                    if self._speaker_allowed(speaker)
+                ]
 
             for speaker in speakers:
                 self._prime_if_needed(speaker)
@@ -399,30 +496,26 @@ class ZeroConfPrimer:
             # or send a power_on event.
             with self._lock:
                 to_remove = [
-                    did
-                    for did, s in self._speakers.items()
-                    if s.prime_failures >= MAX_CONSECUTIVE_FAILURES
+                    device_id
+                    for device_id, speaker in self._speakers.items()
+                    if speaker.prime_failures >= MAX_CONSECUTIVE_FAILURES
                 ]
-                for did in to_remove:
-                    s = self._speakers.pop(did)
+                for device_id in to_remove:
+                    speaker = self._speakers.pop(device_id)
                     logger.warning(
                         "Removed unreachable speaker %s (%s) after %d consecutive failures",
-                        did,
-                        s.ip_address,
-                        s.prime_failures,
+                        device_id,
+                        speaker.ip_address,
+                        speaker.prime_failures,
                     )
 
         except Exception:
-            logger.exception("Error during periodic Spotify primer")
+            logger.exception("Error during periodic Spotify ZeroConf primer")
         finally:
             self._schedule_next()
 
     @staticmethod
     def _send_add_user(speaker_ip: str, user_id: str, token: str) -> dict:
-        logger.info(
-            f"DEBUG:  trying to add user {user_id} to {speaker_ip} but not really"
-        )
-
         """Send addUser to the speaker's ZeroConf endpoint."""
         post_data = urllib.parse.urlencode(
             {


### PR DESCRIPTION
# Add optional Spotify ZeroConf primer for cold-started SoundTouch speakers

## Summary

- Adds an opt-in Spotify ZeroConf primer for SoundTouch speakers that do not reliably start Spotify presets after a cold boot.
- Keeps the primer disabled by default and requires an explicit device allowlist before any speaker is primed.
- Wires the primer into FastAPI lifespan startup/shutdown, speaker registration, and the `power_on` path.
- Makes Spotify OAuth scopes configurable and documents relinking requirements when scopes change.
- Adds Spotify service and ZeroConf primer tests.

## Testing

- `uv run --python 3.12 --with-requirements requirements.txt pytest`
- `uv run --python 3.12 --with-requirements requirements.txt black --target-version py312 --check .`
- `uv run --python 3.12 --with-requirements requirements.txt isort --check-only .`
- `uv run --python 3.12 --with-requirements requirements.txt mypy .`

Result on this branch: `37 passed, 1 warning`.

## Notes

- Users may need to relink Spotify accounts if their stored refresh token lacks the new `streaming` scope.
- The primer uses local speaker ZeroConf calls and should remain allowlist-gated.
- With multiple Gunicorn workers, more than one worker may attempt priming; single-worker deployment is recommended when enabling the primer until upstream chooses a shared worker model.
