### PR TITLE
Fix miniapp preset playback and cookie encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,5 +43,5 @@ plugins = ["pydantic.mypy"]
 minversion = "9.0"
 addopts = ["-ra", "--cov=soundcork", "--cov-report=term-missing:skip-covered"]
 testpaths = [
-    "tests",
+    "soundcork/tests",
 ]

--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -4,8 +4,9 @@ Endpoints for a miniapp UI.
 
 import logging
 from typing import TYPE_CHECKING
+from urllib.parse import quote, unquote
 
-from fastapi import APIRouter, Request, Response
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
@@ -17,6 +18,17 @@ if TYPE_CHECKING:
     from soundcork.model import Preset
 
 logger = logging.getLogger(__name__)
+
+
+def encode_cookie_value(value: object) -> str:
+    """Encode text for Set-Cookie's latin-1 constrained header value."""
+    return quote(str(value), safe="")
+
+
+def decode_cookie_value(value: str | None, default: str | None = None) -> str | None:
+    if value is None:
+        return default
+    return unquote(value)
 
 
 def get_device_image(product_code: str) -> str:
@@ -110,7 +122,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             )
             response.set_cookie(
                 key="soundcork_account_label",
-                value=account_label,
+                value=encode_cookie_value(account_label),
                 max_age=86400 * 30,
                 httponly=False,  # Allow JS to read for display
                 samesite="strict",
@@ -128,11 +140,12 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
     @router.get("/miniapp/dashboard", response_class=HTMLResponse)
     async def dashboard_page(request: Request):
         """Display dashboard with devices and presets."""
+        account_id = ""
         try:
             # Get account from cookie
-            account_id = request.cookies.get("soundcork_account_id")
-            account_label = request.cookies.get(
-                "soundcork_account_label", "Unknown Account"
+            account_id = request.cookies.get("soundcork_account_id", "")
+            account_label = decode_cookie_value(
+                request.cookies.get("soundcork_account_label"), "Unknown Account"
             )
 
             if not account_id:
@@ -194,13 +207,12 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             )
 
             # Get selected content_item and device from cookies
-            selected_content_item = request.cookies.get(
-                "soundcork_selected_content_item_name"
+            selected_content_item = decode_cookie_value(
+                request.cookies.get("soundcork_selected_content_item_name")
             )
-            selected_content_item = request.cookies.get(
-                "soundcork_selected_content_item_name"
+            selected_device = decode_cookie_value(
+                request.cookies.get("soundcork_selected_device")
             )
-            selected_device = request.cookies.get("soundcork_selected_device")
             selected_device_id = request.cookies.get("soundcork_selected_device_id")
             is_playing = request.cookies.get("soundcork_is_playing", "false")
 
@@ -224,10 +236,12 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             logger.error(f"Error rendering dashboard: {e}")
 
             # Still try to get selected content_item/device from cookies
-            selected_content_item = request.cookies.get(
-                "soundcork_selected_content_item_name"
+            selected_content_item = decode_cookie_value(
+                request.cookies.get("soundcork_selected_content_item_name")
             )
-            selected_device = request.cookies.get("soundcork_selected_device")
+            selected_device = decode_cookie_value(
+                request.cookies.get("soundcork_selected_device")
+            )
             selected_device_id = request.cookies.get("soundcork_selected_device_id")
             is_playing = request.cookies.get("soundcork_is_playing", "false")
 
@@ -235,7 +249,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 request=request,
                 name="dashboard.html",
                 context={
-                    "account_id": "",
+                    "account_id": account_id,
                     "account_label": "Unknown",
                     "devices": [],
                     "presets": [],
@@ -252,16 +266,21 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         """Handle content_item selection and set cookie."""
         try:
             form_data = await request.form()
-            content_item_id = str(form_data.get("content_item_id"))
-            content_item_name = str(form_data.get("content_item_name"))
+            content_item_id = form_data.get("content_item_id")
+            content_item_name = form_data.get("content_item_name")
 
-            if not content_item_id or not content_item_name:
+            if (
+                not isinstance(content_item_id, str)
+                or not isinstance(content_item_name, str)
+                or not content_item_id
+                or not content_item_name
+            ):
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
             response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
             response.set_cookie(
                 key="soundcork_selected_content_item_name",
-                value=content_item_name,
+                value=encode_cookie_value(content_item_name),
                 max_age=86400 * 30,  # 30 days
                 httponly=False,
                 samesite="strict",
@@ -273,6 +292,26 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 httponly=False,
                 samesite="strict",
             )
+
+            selected_device_id = request.cookies.get("soundcork_selected_device_id")
+            if selected_device_id:
+                success = speakers.play_content_item(
+                    selected_device_id, content_item_id
+                )
+                response.set_cookie(
+                    key="soundcork_is_playing",
+                    value="true" if success else "false",
+                    max_age=86400 * 30,
+                    httponly=False,
+                    samesite="strict",
+                )
+                if success:
+                    logger.info(
+                        f"Started playback from preset click: content_item {content_item_id} on device {selected_device_id}"
+                    )
+                else:
+                    logger.error("Failed to start playback from preset click")
+
             return response
 
         except Exception as e:
@@ -287,13 +326,18 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             device_id = form_data.get("device_id")
             device_name = form_data.get("device_name")
 
-            if not device_id or not device_name:
+            if (
+                not isinstance(device_id, str)
+                or not isinstance(device_name, str)
+                or not device_id
+                or not device_name
+            ):
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
             response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
             response.set_cookie(
                 key="soundcork_selected_device",
-                value=str(device_name),
+                value=encode_cookie_value(device_name),
                 max_age=86400 * 30,  # 30 days
                 httponly=False,
                 samesite="strict",
@@ -301,7 +345,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             # Also store device_id for future use
             response.set_cookie(
                 key="soundcork_selected_device_id",
-                value=str(device_id),
+                value=device_id,
                 max_age=86400 * 30,
                 httponly=True,
                 samesite="strict",
@@ -318,8 +362,8 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         """Play the selected content_item on the selected device."""
         try:
             # Get content_item and device from cookies
-            selected_content_item = request.cookies.get(
-                "soundcork_selected_content_item_name"
+            selected_content_item = decode_cookie_value(
+                request.cookies.get("soundcork_selected_content_item_name")
             )
             selected_content_item_id = request.cookies.get(
                 "soundcork_selected_content_item_id"
@@ -399,6 +443,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         response.delete_cookie("soundcork_account_id")
         response.delete_cookie("soundcork_account_label")
         response.delete_cookie("soundcork_selected_content_item_name")
+        response.delete_cookie("soundcork_selected_content_item_id")
         response.delete_cookie("soundcork_selected_device")
         response.delete_cookie("soundcork_selected_device_id")
         response.delete_cookie("soundcork_is_playing")

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.miniapp import get_miniapp_router
+from soundcork.model import Preset
+
+ACCOUNT_ID = "8208423"
+DEVICE_ID = "device-1"
+
+
+class FakeDatastore:
+    def account_exists(self, account_id: str) -> bool:
+        return account_id == ACCOUNT_ID
+
+    def list_accounts(self) -> list[str]:
+        return [ACCOUNT_ID]
+
+    def get_account_info(self, account_id: str) -> str:
+        assert account_id == ACCOUNT_ID
+        return "Účet ložnice"
+
+    def list_devices(self, account_id: str) -> list[str]:
+        assert account_id == ACCOUNT_ID
+        return [DEVICE_ID]
+
+    def get_device_info(self, account_id: str, device_id: str):
+        assert account_id == ACCOUNT_ID
+        assert device_id == DEVICE_ID
+        return SimpleNamespace(
+            name="ložnice",
+            product_code="SoundTouch10",
+            device_id=DEVICE_ID,
+        )
+
+    def get_presets(self, account_id: str) -> list[Preset]:
+        assert account_id == ACCOUNT_ID
+        return [
+            Preset(
+                id="4",
+                name="Rádio Proglas",
+                source="LOCAL_INTERNET_RADIO",
+                type="STORED_MUSIC",
+                location="proglas",
+                container_art="",
+            )
+        ]
+
+
+class FakeSpeakers:
+    def __init__(self, play_result: bool = True) -> None:
+        self.play_result = play_result
+        self.play_calls: list[tuple[str, str]] = []
+
+    def all_devices(self):
+        return {
+            DEVICE_ID: SimpleNamespace(
+                account=ACCOUNT_ID,
+                online=True,
+                in_soundcork=True,
+                marge_server="Soundcork",
+            )
+        }
+
+    def play_content_item(self, device_id: str, content_item_id: str) -> bool:
+        self.play_calls.append((device_id, content_item_id))
+        return self.play_result
+
+
+def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
+    monkeypatch.chdir(Path(__file__).resolve().parents[1])
+    app = FastAPI()
+    fake_speakers = speakers or FakeSpeakers()
+    app.include_router(
+        get_miniapp_router(cast(Any, FakeDatastore()), cast(Any, fake_speakers))
+    )
+    return TestClient(app), fake_speakers
+
+
+def set_cookie_headers(response) -> list[str]:
+    return response.headers.get_list("set-cookie")
+
+
+def test_select_device_percent_encodes_unicode_cookie(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/select-device",
+        data={"device_id": DEVICE_ID, "device_name": "ložnice"},
+        follow_redirects=False,
+    )
+
+    cookies = "\n".join(set_cookie_headers(response))
+    assert response.status_code == 303
+    assert "soundcork_selected_device=lo%C5%BEnice" in cookies
+    assert "ložnice" not in cookies
+
+
+def test_dashboard_decodes_display_cookies(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.get(
+        "/miniapp/dashboard",
+        headers={
+            "Cookie": (
+                f"soundcork_account_id={ACCOUNT_ID}; "
+                "soundcork_account_label=%C3%9A%C4%8Det%20lo%C5%BEnice; "
+                "soundcork_selected_device=lo%C5%BEnice; "
+                "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas; "
+                f"soundcork_selected_device_id={DEVICE_ID}"
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    assert "Účet ložnice" in response.text
+    assert "ložnice" in response.text
+    assert "Rádio Proglas" in response.text
+
+
+def test_select_content_item_plays_when_device_is_selected(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/select-content-item",
+        data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
+        headers={"Cookie": f"soundcork_selected_device_id={DEVICE_ID}"},
+        follow_redirects=False,
+    )
+
+    cookies = "\n".join(set_cookie_headers(response))
+    assert response.status_code == 303
+    assert speakers.play_calls == [(DEVICE_ID, "4")]
+    assert "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas" in cookies
+    assert "soundcork_is_playing=true" in cookies
+
+
+def test_select_content_item_without_device_only_selects(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/select-content-item",
+        data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
+        follow_redirects=False,
+    )
+
+    cookies = "\n".join(set_cookie_headers(response))
+    assert response.status_code == 303
+    assert speakers.play_calls == []
+    assert "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas" in cookies
+    assert "soundcork_is_playing" not in cookies
+
+
+def test_select_content_item_records_failed_playback(monkeypatch):
+    client, speakers = make_client(monkeypatch, FakeSpeakers(play_result=False))
+
+    response = client.post(
+        "/miniapp/select-content-item",
+        data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
+        headers={"Cookie": f"soundcork_selected_device_id={DEVICE_ID}"},
+        follow_redirects=False,
+    )
+
+    cookies = "\n".join(set_cookie_headers(response))
+    assert response.status_code == 303
+    assert speakers.play_calls == [(DEVICE_ID, "4")]
+    assert "soundcork_is_playing=false" in cookies


### PR DESCRIPTION
# Fix miniapp preset playback and cookie encoding

## Summary

- Percent-encodes miniapp display cookie values so non-ASCII account, device, and preset names are safe for `Set-Cookie` headers.
- Decodes those cookies before rendering miniapp state.
- Starts playback immediately when a preset is selected and a device has already been selected.
- Clears the selected content item cookie on logout.
- Adds miniapp tests and points pytest discovery at `soundcork/tests`.

## Testing

- `uv run --python 3.12 --with-requirements requirements.txt pytest`
- `uv run --python 3.12 --with-requirements requirements.txt black --target-version py312 --check .`
- `uv run --python 3.12 --with-requirements requirements.txt isort --check-only .`
- `uv run --python 3.12 --with-requirements requirements.txt mypy .`

Result on this branch: `31 passed, 1 warning`.

## Notes

- The cookie change is only encoding for HTTP header safety; it does not make display cookies confidential.
- Direct preset playback still depends on the existing speaker reachability and `Speakers.play_content_item` behavior.
- Related to #316 only for the miniapp symptom where selecting a preset did not
  immediately start playback after a device was already selected. This PR does
  not implement or fix physical preset-button handling, nor the missing
  `/streaming/sourceproviders` or `/streaming/device/{deviceId}/streaming_token`
  endpoints mentioned in that issue.
