### PR TITLE
Harden non-rooted SoundTouch account data handling

### DIFF
--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -561,6 +561,9 @@ class DataStore:
         name = strip_element_text(info_elem.find("name"))
         type = strip_element_text(info_elem.find("type"))
         module_type = strip_element_text(info_elem.find("moduleType"))
+        product_code = type
+        if module_type and not type.lower().endswith(f" {module_type.lower()}"):
+            product_code = f"{type} {module_type}"
 
         try:
             components = info_elem.find("components").findall("component")  # type: ignore
@@ -598,7 +601,7 @@ class DataStore:
         try:
             return DeviceInfo(
                 device_id=device_id,
-                product_code=f"{type} {module_type}",
+                product_code=product_code,
                 device_serial_number=str(device_serial_number),
                 product_serial_number=str(product_serial_number),
                 firmware_version=str(firmware_version),

--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -110,6 +110,8 @@ class DataStore:
         except FileNotFoundError:
             # Initialize the file if it doesn't exist
             self.initialize_accounts_file()
+            with open(path.join(self.data_dir, ACCOUNTS_FILE), "r") as f:
+                accounts = json.load(f)
         if account not in accounts:
             self.save_account_info(account, f"{DEFAULT_ACCOUNT_LABEL} {account}")
             return f"{DEFAULT_ACCOUNT_LABEL} {account}"
@@ -120,7 +122,8 @@ class DataStore:
         """Saves the label for the given account"""
         with open(path.join(self.data_dir, ACCOUNTS_FILE), "r") as f:
             accounts = json.load(f)
-        if account_label := accounts.get(label):
+        if account_info := accounts.get(account):
+            account_label = account_info.get("label")
             if account_label == label:
                 return
             logger.warning(
@@ -456,6 +459,9 @@ class DataStore:
     # TODO: add error handling if you can't write the file
     def save_configured_sources_xml(self, account: str, sources_xml: str):
         """Write Sources.xml for an Account"""
+        if not sources_xml.strip():
+            logger.info(f"not writing empty {SOURCES_FILE} for account {account}")
+            return
         with open(
             path.join(self.account_dir(account), SOURCES_FILE), "w"
         ) as sources_file:

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -69,15 +69,19 @@ def read_presets(hostname: str) -> str:
 
 def read_sources(hostname: str) -> str:
     sources_tmp_file = tempfile.NamedTemporaryFile(delete=False)
-    read_file_from_speaker_ssh(
-        host=hostname,
-        remote_path=SPEAKER_SOURCES_FILE_LOCATION,
-        local_path=sources_tmp_file.name,
-    )
-    sources = sources_tmp_file.read()
     sources_tmp_file.close()
-    unlink(sources_tmp_file.name)
-    return sources.decode()
+    try:
+        copied = read_file_from_speaker_ssh(
+            host=hostname,
+            remote_path=SPEAKER_SOURCES_FILE_LOCATION,
+            local_path=sources_tmp_file.name,
+        )
+        if not copied:
+            return ""
+        with open(sources_tmp_file.name, "rb") as sources_file:
+            return sources_file.read().decode()
+    finally:
+        unlink(sources_tmp_file.name)
 
 
 def override_speaker_config(host: str) -> bool:
@@ -159,7 +163,7 @@ def reboot_speaker(host: str) -> bool:
         return False
 
 
-def read_file_from_speaker_ssh(host: str, remote_path: str, local_path: str) -> None:
+def read_file_from_speaker_ssh(host: str, remote_path: str, local_path: str) -> bool:
     """Read a file from the remote speaker, using ssh."""
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -168,8 +172,10 @@ def read_file_from_speaker_ssh(host: str, remote_path: str, local_path: str) -> 
 
         with SCPClient(ssh.get_transport()) as scp:
             scp.get(remote_path, local_path)
+        return True
     except Exception as e:
         logger.info(f"Error: {e}")
+        return False
 
 
 def read_file_from_speaker_http(host: str, path: str) -> str:
@@ -285,7 +291,10 @@ def add_account(
         return False
     datastore.save_presets_xml(account_id, presets)
     datastore.save_recents_xml(account_id, recents)
-    datastore.save_configured_sources_xml(account_id, sources)
+    if sources.strip():
+        datastore.save_configured_sources_xml(account_id, sources)
+    else:
+        logger.info(f"skipping empty Sources.xml for account {account_id}")
 
     return True
 

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -263,6 +263,13 @@ def add_device_by_ip(hostname: str, reachable: bool = True) -> bool:
             if reachable:
                 sources = read_sources(hostname)
             else:
+                fallback_sources = default_sources()
+                recents = _filter_items_for_sources(
+                    recents, "recent", "contentItem", fallback_sources
+                )
+                presets = _filter_items_for_sources(
+                    presets, "preset", "ContentItem", fallback_sources
+                )
                 sources = default_sources_string()
             logger.info(f"sources={sources}")
             # FIXME get the account email address for this
@@ -278,6 +285,42 @@ def add_device_by_ip(hostname: str, reachable: bool = True) -> bool:
         )  # type: ignore
         return True
     return False
+
+
+def _filter_items_for_sources(
+    items_xml: str,
+    item_tag: str,
+    content_item_tag: str,
+    sources: list[ConfiguredSource],
+) -> str:
+    """Remove imported items that cannot be represented by available sources."""
+    root = ET.fromstring(items_xml)
+    source_keys = {
+        (source.source_key_type, source.source_key_account) for source in sources
+    }
+    removed = 0
+    for item in list(root.findall(item_tag)):
+        content_item = item.find(content_item_tag)
+        if content_item is None:
+            continue
+        source_key = (
+            content_item.attrib.get("source", ""),
+            content_item.attrib.get("sourceAccount", ""),
+        )
+        if source_key not in source_keys:
+            root.remove(item)
+            removed += 1
+
+    if not removed:
+        return items_xml
+
+    logger.info(
+        "removed %d %s entries without an available configured source",
+        removed,
+        item_tag,
+    )
+    ET.indent(root, space="    ", level=0)
+    return ET.tostring(root, xml_declaration=True, encoding="UTF-8").decode()
 
 
 def add_account(

--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -54,7 +54,7 @@ def decode_cookie_value(value: str | None, default: str | None = None) -> str | 
 
 def get_device_image(product_code: str) -> str:
     """Map product code to device image file."""
-    return DEVICE_IMAGE_MAP.get(product_code.lower(), DEFAULT_DEVICE_IMAGE)
+    return DEVICE_IMAGE_MAP.get(product_code.strip().lower(), DEFAULT_DEVICE_IMAGE)
 
 
 def get_miniapp_router(datastore: DataStore, speakers: Speakers):
@@ -218,11 +218,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                     online = "offline"
                     cd = my_combined_devices[device_id]
                     device_info = datastore.get_device_info(account_id, device_id)
-                    if (
-                        cd.online
-                        and cd.in_soundcork
-                        and (cd.marge_server == "Soundcork")
-                    ):
+                    if cd.online and cd.in_soundcork:
                         online = "online"
                     devices.append(
                         {

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -125,6 +125,67 @@ def test_get_device_info(
     assert result.name == sample_device.name
 
 
+def test_device_info_from_device_info_xml_does_not_append_empty_module_type(
+    datastore: DataStore,
+):
+    xml = ET.fromstring("""
+        <info deviceID="2C6B7D49B097">
+            <name>kuchyn</name>
+            <type>SoundTouch 10 sm2</type>
+            <components>
+                <component>
+                    <componentCategory>SCM</componentCategory>
+                    <softwareVersion>1</softwareVersion>
+                    <serialNumber>A</serialNumber>
+                </component>
+                <component>
+                    <componentCategory>PackagedProduct</componentCategory>
+                    <serialNumber>B</serialNumber>
+                </component>
+            </components>
+            <networkInfo type="SCM">
+                <macAddress>2C6B7D49B097</macAddress>
+                <ipAddress>192.168.11.71</ipAddress>
+            </networkInfo>
+        </info>
+    """)
+
+    result = datastore.device_info_from_device_info_xml(xml)
+
+    assert result.product_code == "SoundTouch 10 sm2"
+
+
+def test_device_info_from_device_info_xml_appends_present_module_type(
+    datastore: DataStore,
+):
+    xml = ET.fromstring("""
+        <info deviceID="2C6B7D49B097">
+            <name>kuchyn</name>
+            <type>SoundTouch 10</type>
+            <moduleType>sm2</moduleType>
+            <components>
+                <component>
+                    <componentCategory>SCM</componentCategory>
+                    <softwareVersion>1</softwareVersion>
+                    <serialNumber>A</serialNumber>
+                </component>
+                <component>
+                    <componentCategory>PackagedProduct</componentCategory>
+                    <serialNumber>B</serialNumber>
+                </component>
+            </components>
+            <networkInfo type="SCM">
+                <macAddress>2C6B7D49B097</macAddress>
+                <ipAddress>192.168.11.71</ipAddress>
+            </networkInfo>
+        </info>
+    """)
+
+    result = datastore.device_info_from_device_info_xml(xml)
+
+    assert result.product_code == "SoundTouch 10 sm2"
+
+
 def test_save_device_info_returns_object_and_writes_file(
     datastore: DataStore,
     sample_device: DeviceInfo,

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -2,6 +2,7 @@
 
 These tests mock out all filesystem interactions and focus on logic."""
 
+import json
 import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock, call, mock_open
 
@@ -213,6 +214,21 @@ def test_create_account_returns_false_if_account_dir_present(
 
     assert created is False
     mkdir_mock.assert_not_called()
+
+
+def test_get_account_info_initializes_file_and_returns_default_label(
+    tmp_path, monkeypatch
+):
+    account_dir = tmp_path / "12345"
+    account_dir.mkdir()
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", str(tmp_path))
+    datastore = DataStore()
+
+    label = datastore.get_account_info("12345")
+
+    assert label == "Unnamed account 12345"
+    accounts = json.loads((tmp_path / "Accounts.json").read_text())
+    assert accounts == {"12345": {"label": "Unnamed account 12345"}}
 
 
 def test_add_device_returns_none_if_account_device_dir_missing(
@@ -592,6 +608,17 @@ def test_save_xml_helpers_open_files_to_write(datastore: DataStore, monkeypatch)
     datastore.save_configured_sources_xml("12345", "<sources />")
 
     assert open_mock.call_count == 3
+
+
+def test_save_configured_sources_xml_skips_empty_source_payload(tmp_path, monkeypatch):
+    account_dir = tmp_path / "12345"
+    account_dir.mkdir()
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", str(tmp_path))
+    datastore = DataStore()
+
+    datastore.save_configured_sources_xml("12345", "")
+
+    assert not (account_dir / "Sources.xml").exists()
 
 
 def test_etag_for_account_correctly_finds_max(datastore: DataStore, monkeypatch):

--- a/soundcork/tests/test_devices.py
+++ b/soundcork/tests/test_devices.py
@@ -1,0 +1,22 @@
+from unittest.mock import MagicMock
+
+from soundcork.devices import add_account
+
+
+def test_add_account_skips_sources_xml_when_source_copy_failed(monkeypatch):
+    datastore = MagicMock()
+    datastore.create_account.return_value = True
+    monkeypatch.setattr("soundcork.devices.datastore", datastore)
+
+    added = add_account(
+        account_id="12345",
+        recents="<recents />",
+        presets="<presets />",
+        sources="",
+        account_name=None,
+    )
+
+    assert added is True
+    datastore.save_presets_xml.assert_called_once_with("12345", "<presets />")
+    datastore.save_recents_xml.assert_called_once_with("12345", "<recents />")
+    datastore.save_configured_sources_xml.assert_not_called()

--- a/soundcork/tests/test_devices.py
+++ b/soundcork/tests/test_devices.py
@@ -1,6 +1,7 @@
+import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock
 
-from soundcork.devices import add_account
+from soundcork.devices import _filter_items_for_sources, add_account, default_sources
 
 
 def test_add_account_skips_sources_xml_when_source_copy_failed(monkeypatch):
@@ -20,3 +21,47 @@ def test_add_account_skips_sources_xml_when_source_copy_failed(monkeypatch):
     datastore.save_presets_xml.assert_called_once_with("12345", "<presets />")
     datastore.save_recents_xml.assert_called_once_with("12345", "<recents />")
     datastore.save_configured_sources_xml.assert_not_called()
+
+
+def test_filter_items_for_sources_removes_unavailable_recent_source():
+    recents = """
+        <recents>
+            <recent id="1">
+                <contentItem source="LOCAL_INTERNET_RADIO">
+                    <itemName>Radio Proglas</itemName>
+                </contentItem>
+            </recent>
+            <recent id="2">
+                <contentItem source="SPOTIFY" sourceAccount="listener">
+                    <itemName>Spotify item</itemName>
+                </contentItem>
+            </recent>
+        </recents>
+    """
+
+    filtered = _filter_items_for_sources(
+        recents, "recent", "contentItem", default_sources()
+    )
+
+    items = ET.fromstring(filtered).findall("recent")
+    assert [item.findtext("contentItem/itemName") for item in items] == [
+        "Radio Proglas"
+    ]
+
+
+def test_filter_items_for_sources_keeps_unchanged_supported_presets():
+    presets = """
+        <presets>
+            <preset id="1">
+                <ContentItem source="TUNEIN">
+                    <itemName>Radio station</itemName>
+                </ContentItem>
+            </preset>
+        </presets>
+    """
+
+    filtered = _filter_items_for_sources(
+        presets, "preset", "ContentItem", default_sources()
+    )
+
+    assert filtered == presets

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from soundcork.miniapp import get_miniapp_router
+from soundcork.miniapp import get_device_image, get_miniapp_router
 from soundcork.model import Preset
 
 ACCOUNT_ID = "8208423"
@@ -99,3 +99,7 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
 
     assert response.status_code == 200
     assert "Účet ložnice" in response.text
+
+
+def test_get_device_image_normalizes_product_code_whitespace():
+    assert get_device_image("SoundTouch 10 sm2 ") == "d9.png"


### PR DESCRIPTION
# Non-Rooted SoundTouch Account Setup

## Title

Support non-rooted SoundTouch account setup from the admin UI

## Summary

- Allow account/device import to proceed when a SoundTouch speaker exposes `/info`, `/presets`, and `/recents` over HTTP but does not allow root SSH/SCP access.
- Treat `Sources.xml` as optional during initial account import: failed source-file copy now returns an empty payload and account creation skips writing an empty/invalid `Sources.xml`.
- When an SSH-less import uses the safe fallback source list, omit only copied presets and recents that cannot be represented by those sources. This prevents one stale item such as a Spotify recent from breaking the complete Marge `/devices` and `/full` responses.
- Fix account metadata initialization so a missing `Accounts.json` is created and reloaded before returning the default account label.
- Fix account label updates to check the account id entry instead of looking up by label text.
- Keep miniapp devices selectable when they are online and registered in SoundCork, even if the speaker still reports Bose as its Marge server.
- Normalize stored product codes so saved non-rooted devices keep the correct model image instead of falling back to the SoundTouch 30 default.
- Clarify the admin UI column from `Reachable` to `SSH/shell access`.

## Why This Is Needed

Non-rooted SoundTouch speakers can still provide the account id, device info, presets, and recents through the normal HTTP API, but they cannot copy `/mnt/nv/BoseApp-Persistence/1/Sources.xml` over SSH. The previous setup path treated that SSH-only source file as part of account import, which could leave an empty `Sources.xml` in the datastore and break later source parsing.

The admin add-device flow also makes these HTTP-visible devices available to the miniapp. They may still report Bose as their Marge server until a rooted override is installed, but miniapp playback control uses the local SoundTouch API and only needs the device to be online and present in SoundCork. This change lets that non-rooted path preserve and use the available local account/device data without requiring root shell access.

Related roadmap item: #299. This PR covers the non-rooted/non-SSH add-device path and clarifies the admin reachability label, but it does not complete the full #299 scope.

## Implementation Details

- `read_file_from_speaker_ssh()` now returns `True` or `False` so callers can distinguish a successful SCP copy from an SSH/SCP failure.
- `read_sources()` closes the temp file before SCP, reads it only after a successful copy, and always removes the temp file.
- `add_account()` skips `save_configured_sources_xml()` when the source payload is empty or whitespace.
- SSH-less imports filter their local copies of presets and recents against the fallback source keys before saving them. The speaker's own data is not modified.
- `DataStore.save_configured_sources_xml()` also guards against empty writes, so empty `Sources.xml` payloads are not persisted through other call paths.
- `DataStore.get_account_info()` now reloads `Accounts.json` after initializing it.
- `DataStore.save_account_info()` now compares the existing label for the target account id.
- `DataStore.device_info_from_device_info_xml()` no longer appends an empty module type, and avoids duplicating an already-saved module suffix.
- `get_device_image()` strips product-code whitespace before lookup.
- The miniapp marks a device online when it is both discovered and present in SoundCork, without requiring `marge_server == "Soundcork"`.
- Added focused unit coverage for empty source handling and account-file initialization.

## Tests / Validation

- Added `soundcork/tests/test_devices.py::test_add_account_skips_sources_xml_when_source_copy_failed`.
- Added focused `soundcork/tests/test_devices.py` coverage for retaining supported items and omitting unavailable sources.
- Added `soundcork/tests/test_datastore.py::test_save_configured_sources_xml_skips_empty_source_payload`.
- Added `soundcork/tests/test_datastore.py::test_get_account_info_initializes_file_and_returns_default_label`.
- Added product-code normalization coverage in `soundcork/tests/test_datastore.py` and `soundcork/tests/test_miniapp.py`.
- `git diff --check`
- `black --check soundcork/datastore.py soundcork/devices.py soundcork/miniapp.py soundcork/tests/test_datastore.py soundcork/tests/test_devices.py soundcork/tests/test_miniapp.py`
- `isort --check-only soundcork/datastore.py soundcork/devices.py soundcork/miniapp.py soundcork/tests/test_datastore.py soundcork/tests/test_devices.py soundcork/tests/test_miniapp.py`
- `python -m py_compile soundcork/datastore.py soundcork/devices.py soundcork/miniapp.py soundcork/tests/test_datastore.py soundcork/tests/test_devices.py soundcork/tests/test_miniapp.py`
- `mypy soundcork/datastore.py soundcork/devices.py soundcork/miniapp.py`
- `pytest soundcork/tests/test_datastore.py soundcork/tests/test_miniapp.py soundcork/tests/test_devices.py` (`37 passed`)
- `pytest soundcork/tests` (`37 passed`)

## Compatibility / Risk Notes

- Rooted or USB-enabled speakers that allow SSH/SCP should keep the previous behavior: `Sources.xml` is copied and stored when available.
- Non-rooted account imports retain only presets and recents represented by the safe fallback sources in SoundCork's local copy. Unsupported entries remain untouched on the speaker and can be imported later if richer source metadata becomes available.
- The miniapp can now select locally online registered devices even before they are switched to SoundCork Marge. Actual playback still depends on the selected preset/content item being playable through the speaker's local SoundTouch API.
- Switching a speaker to SoundCork by writing `OverrideSdkPrivateCfg.xml` and rebooting still requires SSH/shell access. This PR does not make firmware override operations possible on non-rooted speakers.
- The admin UI wording now distinguishes general network availability from SSH/shell access, but this branch intentionally keeps the existing broader admin flow structure.

## Follow-Ups Out Of Scope

- Synthesizing configured sources from presets, recents, or provider metadata when `Sources.xml` cannot be copied.
- Adding a first-class empty-source fallback in every API path that currently assumes `Sources.xml` exists.
- Adding an admin/API path to set friendly account labels manually, or importing
  labels from an existing SoundCork `Accounts.json` when available.
- Handling factory-reset or otherwise misconfigured devices that do not expose
  a usable account id, including #317 and #302.
- Completing the rest of #299, such as device naming, a broader admin redesign,
  and robustly listing/skipping every class of misconfigured device.
- Redesigning the admin add-device flow or changing the switch-to-SoundCork SSH requirements.
- Adding end-to-end coverage with real rooted and non-rooted SoundTouch hardware.
