### PR TITLE
Support running Soundcork on Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.11", "3.12"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license-files = ["LICENSE.md"]
 authors = [{ name = "Deborah Kaplan" }, { name = "Allen Petersen" }]
 maintainers = [{ name = "Deborah Kaplan" }, { name = "Allen Petersen" }]
 
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 dynamic = ["dependencies"]
 
 

--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -4,7 +4,7 @@ import random
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 from http import HTTPStatus
-from os import listdir, mkdir, path, remove, rmdir, walk
+from os import listdir, makedirs, mkdir, path, remove, rmdir, walk
 from random import randint
 from typing import Optional
 
@@ -53,6 +53,13 @@ class DataStore:
     def __init__(self) -> None:
         logger.info("Initiating Datastore")
         self.data_dir = settings.data_dir
+        self.ensure_data_dir()
+
+    def ensure_data_dir(self) -> None:
+        """Ensure the configured datastore directory exists."""
+        if not self.data_dir:
+            raise RuntimeError("Soundcork data_dir is not configured")
+        makedirs(self.data_dir, exist_ok=True)
 
     def poweron_devices_dir(self) -> str:
         """returns the top-level directory that stores poweron info for all devices"""
@@ -647,6 +654,9 @@ class DataStore:
 
         If no accounts have been created, returns an empty list.
         """
+        if not path.exists(self.data_dir):
+            return []
+
         accounts: list[str | None] = []
         for account_id in next(walk(self.data_dir))[1]:
             # Check if the ID is digits to distinguish between accounts and power_on devices.
@@ -660,6 +670,9 @@ class DataStore:
 
         If the account has no devices, returns an empty list.
         """
+        if not path.exists(self.account_devices_dir(account_id)):
+            return []
+
         devices: list[str | None] = []
         for device_id in next(walk(self.account_devices_dir(account_id)))[1]:
             devices.append(device_id)

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -147,9 +147,8 @@ def get_bose_devices() -> list[upnpclient.upnp.Device]:
     devices = upnpclient.discover()
     bose_devices = [d for d in devices if "Bose SoundTouch" in d.model_description]
     logger.info("Discovering upnp devices on the network")
-    logger.info(
-        f'Discovered Bose devices:\n- {"\n- ".join([b.friendly_name for b in bose_devices])}'
-    )
+    device_names = "\n- ".join([b.friendly_name for b in bose_devices])
+    logger.info(f"Discovered Bose devices:\n- {device_names}")
     return bose_devices
 
 

--- a/soundcork/tests/test_datastore.py
+++ b/soundcork/tests/test_datastore.py
@@ -23,6 +23,7 @@ from soundcork.model import ConfiguredSource, DeviceInfo, Preset, Recent
 @pytest.fixture
 def datastore(monkeypatch) -> DataStore:
     monkeypatch.setattr("soundcork.datastore.settings.data_dir", "/virtual/data")
+    monkeypatch.setattr("soundcork.datastore.makedirs", MagicMock())
     return DataStore()
 
 
@@ -65,6 +66,40 @@ def test_poweron_devices_dir_skips_mkdir_when_present(
 
     assert result == f"/virtual/data/{DEVICES_DIR}"
     mkdir_mock.assert_not_called()
+
+
+def test_datastore_creates_configured_data_dir(monkeypatch):
+    makedirs_mock = MagicMock()
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", "/virtual/data")
+    monkeypatch.setattr("soundcork.datastore.makedirs", makedirs_mock)
+
+    datastore = DataStore()
+
+    assert datastore.data_dir == "/virtual/data"
+    makedirs_mock.assert_called_once_with("/virtual/data", exist_ok=True)
+
+
+def test_datastore_raises_when_data_dir_is_not_configured(monkeypatch):
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", "")
+
+    with pytest.raises(RuntimeError, match="data_dir is not configured"):
+        DataStore()
+
+
+def test_list_accounts_returns_empty_when_data_dir_missing(
+    datastore: DataStore, monkeypatch
+):
+    monkeypatch.setattr("soundcork.datastore.path.exists", lambda _: False)
+
+    assert datastore.list_accounts() == []
+
+
+def test_list_devices_returns_empty_when_account_devices_dir_missing(
+    datastore: DataStore, monkeypatch
+):
+    monkeypatch.setattr("soundcork.datastore.path.exists", lambda _: False)
+
+    assert datastore.list_devices("12345") == []
 
 
 def test_account_dir_raises_not_found_when_missing_datastore_dir(
@@ -437,7 +472,10 @@ def test_get_presets_fails_on_empty_item_name(
     assert "name" in str(validerr.value)
 
 
-def test_update_preset_uses_username_when_name_is_missing():
+def test_update_preset_uses_username_when_name_is_missing(monkeypatch):
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", "/virtual/data")
+    monkeypatch.setattr("soundcork.datastore.makedirs", MagicMock())
+
     from soundcork.marge import update_preset
 
     class PresetDatastore:


### PR DESCRIPTION
Lower the package Python requirement to 3.11 and avoid Python 3.12-only f-string syntax in device discovery logging.

Create the configured datastore directory on startup so the runtime does not fail when the data root is missing, and make account/device listing return empty lists when their backing directories have not been created yet.

Add datastore coverage for the startup and missing-directory behavior, fix the preset update test setup for import-time datastore initialization, and run the test workflow on both Python 3.11 and 3.12.

LLM disclosure: I used Codex to scan for Python 3.11 compatibility issues, draft the small test/workflow changes, and run local verification. I reviewed the resulting diff before submitting.

This includes the same fix as proposed in #314.