### PR TITLE
Avoid artificial delay after miniapp playback

### DIFF
--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -188,7 +188,7 @@ class Speakers:
         )
         bose_content_item = self._content_item_to_soundtouchclient(content_item)
         client = SoundTouchClient(cd.st_device)
-        client.PlayContentItem(bose_content_item)
+        client.PlayContentItem(bose_content_item, delay=0)
 
         return True
 


### PR DESCRIPTION
## Summary

- Pass `delay=0` when Soundcork starts a content item through `SoundTouchClient.PlayContentItem`.

## Why

`bosesoundtouchapi` defaults `PlayContentItem(..., delay=5)`. That delay is an artificial sleep after sending the SoundTouch `/select` request, intended to give the device time before another command is accepted. In Soundcork's miniapp path it makes every preset click block for about five extra seconds before the HTTP response returns, even though no immediate follow-up SoundTouch command depends on that wait.

On a local SoundTouch 10, direct `/select` playback reached `PLAY_STATE` in about 1.6-1.7 seconds, while the miniapp path with the default delay reached `PLAY_STATE` in about 6.3-6.4 seconds. After passing `delay=0`, the miniapp path returned in about 0.12 seconds and reached `PLAY_STATE` in about 1.6-2.1 seconds.

I could not find any Soundcork-side comment or follow-up operation that needs this conservative library delay. The delay is useful for client scripts that want to issue another SoundTouch command immediately after selecting content, but in this code path Soundcork only needs to send the select request and return the HTTP response to the miniapp.

There is also a Soundcork-specific consequence when running with a single worker: after the speaker receives `/select`, it calls back into Soundcork for the Orion/BMX station URL. If the same worker is sleeping inside the miniapp request, that callback cannot be served until the artificial delay ends. In that deployment shape, the post-select sleep does not just delay the browser response; it can delay the speaker's actual stream resolution too.

## Implementation

- Change the miniapp playback path in `Speakers.play_content_item()` from `client.PlayContentItem(bose_content_item)` to `client.PlayContentItem(bose_content_item, delay=0)`.
- This still uses the same `bosesoundtouchapi` request path and only removes the post-select sleep.

## Tests / Validation

- `python3 -m py_compile soundcork/ui/speakers.py`
- `uv run python -m pytest soundcork/tests/test_miniapp.py -q`
- Result: `5 passed`, with one existing Pydantic deprecation warning from `soundcork/ui/speakers.py`.

Live validation on a SoundTouch 10:

| Path | Preset | HTTP/request time | PLAY_STATE |
| --- | --- | ---: | ---: |
| Direct `/select` | CRo Vltava | 0.091 s | 1.713 s |
| Miniapp before change | Radio Proglas | 5.110 s | 6.435 s |
| Direct `/select` | CRo D-dur | 0.088 s | 1.632 s |
| Miniapp before change | CRo Vltava | 5.131 s | 6.320 s |
| Miniapp after change | Radio Proglas | 0.127 s | 2.140 s |
| Miniapp after change | CRo D-dur | 0.116 s | 1.621 s |

## Compatibility / Risk

The upstream library documents the delay as time to wait after selecting the item before another command is accepted. Soundcork's miniapp does not need to issue another SoundTouch command immediately after `PlayContentItem`, so removing this sleep should preserve playback behavior while making the UI responsive. Rapid repeated user clicks may still send repeated `/select` requests; this change only avoids blocking the server worker on a fixed sleep.

If a future code path needs to chain another SoundTouch command immediately after playback selection, that path can opt into a delay explicitly. This PR keeps the miniapp/user-triggered playback path responsive.
