### PR TITLE
Clear stale miniapp selections

### DIFF
--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -19,6 +19,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+CONTENT_SELECTION_COOKIES = (
+    "soundcork_selected_content_item_name",
+    "soundcork_selected_content_item_id",
+)
+DEVICE_SELECTION_COOKIES = (
+    "soundcork_selected_device",
+    "soundcork_selected_device_id",
+)
+PLAYBACK_STATE_COOKIES = ("soundcork_is_playing",)
+
 
 def encode_cookie_value(value: object) -> str:
     """Encode text for Set-Cookie's latin-1 constrained header value."""
@@ -36,10 +46,58 @@ def get_device_image(product_code: str) -> str:
     return DEVICE_IMAGE_MAP.get(product_code.lower(), DEFAULT_DEVICE_IMAGE)
 
 
+def delete_cookies(response, cookie_names: tuple[str, ...]) -> None:
+    for cookie_name in cookie_names:
+        response.delete_cookie(cookie_name)
+
+
+def clear_content_selection(response) -> None:
+    delete_cookies(response, CONTENT_SELECTION_COOKIES + PLAYBACK_STATE_COOKIES)
+
+
+def clear_device_selection(response) -> None:
+    delete_cookies(response, DEVICE_SELECTION_COOKIES + PLAYBACK_STATE_COOKIES)
+
+
+def clear_all_selection(response) -> None:
+    clear_content_selection(response)
+    clear_device_selection(response)
+
+
 def get_miniapp_router(datastore: DataStore, speakers: Speakers):
     templates = Jinja2Templates(directory="templates")
 
     router = APIRouter(tags=["miniapp"])
+
+    def device_is_playable_for_account(account_id: str, device_id: str | None) -> bool:
+        if not account_id or not device_id:
+            return False
+
+        combined_device = speakers.all_devices().get(device_id)
+        if not combined_device:
+            return False
+
+        return bool(
+            combined_device.account == account_id
+            and combined_device.online
+            and combined_device.in_soundcork
+            and combined_device.marge_server == "Soundcork"
+        )
+
+    def content_item_exists_for_account(
+        account_id: str, content_item_id: str | None
+    ) -> bool:
+        if not account_id or not content_item_id:
+            return False
+
+        try:
+            return any(
+                str(preset.id) == content_item_id
+                for preset in datastore.get_presets(account_id)
+            )
+        except Exception as e:
+            logger.warning(f"Error validating content item {content_item_id}: {e}")
+            return False
 
     @router.get("/miniapp", response_class=HTMLResponse)
     async def main_page(request: Request):
@@ -127,6 +185,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 httponly=False,  # Allow JS to read for display
                 samesite="strict",
             )
+            clear_all_selection(response)
 
             logger.info(f"User logged in to account {account_id}")
             return response
@@ -210,13 +269,58 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             selected_content_item = decode_cookie_value(
                 request.cookies.get("soundcork_selected_content_item_name")
             )
+            selected_content_item_id = request.cookies.get(
+                "soundcork_selected_content_item_id"
+            )
             selected_device = decode_cookie_value(
                 request.cookies.get("soundcork_selected_device")
             )
             selected_device_id = request.cookies.get("soundcork_selected_device_id")
             is_playing = request.cookies.get("soundcork_is_playing", "false")
 
-            return templates.TemplateResponse(
+            online_device_by_id = {
+                device["device_id"]: device
+                for device in devices
+                if device["status"] == "online"
+            }
+            preset_by_id = {str(preset.id): preset for preset in presets}
+            clear_stale_device = False
+            clear_stale_content = False
+
+            if selected_device_id:
+                selected_device_info = online_device_by_id.get(selected_device_id)
+                if selected_device_info:
+                    selected_device = selected_device_info["name"]
+                else:
+                    logger.info(
+                        f"Clearing stale miniapp device selection {selected_device_id} for account {account_id}"
+                    )
+                    selected_device = None
+                    selected_device_id = None
+                    is_playing = "false"
+                    clear_stale_device = True
+            elif selected_device:
+                selected_device = None
+                is_playing = "false"
+                clear_stale_device = True
+
+            if selected_content_item_id:
+                selected_preset = preset_by_id.get(selected_content_item_id)
+                if selected_preset:
+                    selected_content_item = selected_preset.name
+                else:
+                    logger.info(
+                        f"Clearing stale miniapp content selection {selected_content_item_id} for account {account_id}"
+                    )
+                    selected_content_item = None
+                    is_playing = "false"
+                    clear_stale_content = True
+            elif selected_content_item:
+                selected_content_item = None
+                is_playing = "false"
+                clear_stale_content = True
+
+            response = templates.TemplateResponse(
                 request=request,
                 name="dashboard.html",
                 context={
@@ -231,6 +335,11 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                     "error": None,
                 },
             )
+            if clear_stale_device:
+                clear_device_selection(response)
+            if clear_stale_content:
+                clear_content_selection(response)
+            return response
 
         except Exception as e:
             logger.error(f"Error rendering dashboard: {e}")
@@ -295,22 +404,29 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
 
             selected_device_id = request.cookies.get("soundcork_selected_device_id")
             if selected_device_id:
-                success = speakers.play_content_item(
-                    selected_device_id, content_item_id
-                )
-                response.set_cookie(
-                    key="soundcork_is_playing",
-                    value="true" if success else "false",
-                    max_age=86400 * 30,
-                    httponly=False,
-                    samesite="strict",
-                )
-                if success:
-                    logger.info(
-                        f"Started playback from preset click: content_item {content_item_id} on device {selected_device_id}"
+                account_id = request.cookies.get("soundcork_account_id", "")
+                if device_is_playable_for_account(account_id, selected_device_id):
+                    success = speakers.play_content_item(
+                        selected_device_id, content_item_id
                     )
+                    response.set_cookie(
+                        key="soundcork_is_playing",
+                        value="true" if success else "false",
+                        max_age=86400 * 30,
+                        httponly=False,
+                        samesite="strict",
+                    )
+                    if success:
+                        logger.info(
+                            f"Started playback from preset click: content_item {content_item_id} on device {selected_device_id}"
+                        )
+                    else:
+                        logger.error("Failed to start playback from preset click")
                 else:
-                    logger.error("Failed to start playback from preset click")
+                    logger.info(
+                        f"Ignoring stale miniapp device selection {selected_device_id}"
+                    )
+                    clear_device_selection(response)
 
             return response
 
@@ -335,6 +451,14 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
             response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            account_id = request.cookies.get("soundcork_account_id", "")
+            if not device_is_playable_for_account(account_id, device_id):
+                logger.info(
+                    f"Ignoring unavailable miniapp device selection {device_id} for account {account_id}"
+                )
+                clear_device_selection(response)
+                return response
+
             response.set_cookie(
                 key="soundcork_selected_device",
                 value=encode_cookie_value(device_name),
@@ -374,6 +498,24 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 logger.warning("Cannot play: content_item or device not selected")
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
+            account_id = request.cookies.get("soundcork_account_id", "")
+            response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            if not device_is_playable_for_account(account_id, selected_device_id):
+                logger.info(
+                    f"Ignoring stale miniapp device selection {selected_device_id}"
+                )
+                clear_device_selection(response)
+                return response
+
+            if not content_item_exists_for_account(
+                account_id, selected_content_item_id
+            ):
+                logger.info(
+                    f"Ignoring stale miniapp content selection {selected_content_item_id}"
+                )
+                clear_content_selection(response)
+                return response
+
             logger.info(
                 f"content_item: {selected_content_item}, {selected_content_item_id}"
             )
@@ -383,7 +525,6 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 selected_device_id, str(selected_content_item_id)
             )
 
-            response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
             if success:
                 response.set_cookie(
                     key="soundcork_is_playing",
@@ -414,10 +555,18 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 logger.warning("Cannot stop: device not selected")
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
+            account_id = request.cookies.get("soundcork_account_id", "")
+            response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            if not device_is_playable_for_account(account_id, selected_device_id):
+                logger.info(
+                    f"Ignoring stale miniapp device selection {selected_device_id}"
+                )
+                clear_device_selection(response)
+                return response
+
             # Stop playback
             success = speakers.stop_playback(selected_device_id)
 
-            response = RedirectResponse(url="/miniapp/dashboard", status_code=303)
             if success:
                 response.set_cookie(
                     key="soundcork_is_playing",

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -84,12 +84,22 @@ def set_cookie_headers(response) -> list[str]:
     return response.headers.get_list("set-cookie")
 
 
+def cookie_headers_text(response) -> str:
+    return "\n".join(set_cookie_headers(response))
+
+
+def assert_cookie_deleted(cookies: str, cookie_name: str) -> None:
+    assert f"{cookie_name}=" in cookies
+    assert "Max-Age=0" in cookies
+
+
 def test_select_device_percent_encodes_unicode_cookie(monkeypatch):
     client, _speakers = make_client(monkeypatch)
 
     response = client.post(
         "/miniapp/select-device",
         data={"device_id": DEVICE_ID, "device_name": "ložnice"},
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
         follow_redirects=False,
     )
 
@@ -121,13 +131,71 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
     assert "Rádio Proglas" in response.text
 
 
+def test_login_clears_stale_selection_cookies(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/login",
+        data={"account_id": ACCOUNT_ID},
+        headers={
+            "Cookie": (
+                "soundcork_selected_device=Bos%C3%ADk; "
+                "soundcork_selected_device_id=stale-device; "
+                "soundcork_selected_content_item_name=BBC; "
+                "soundcork_selected_content_item_id=99; "
+                "soundcork_is_playing=true"
+            )
+        },
+        follow_redirects=False,
+    )
+
+    cookies = cookie_headers_text(response)
+    assert response.status_code == 303
+    assert_cookie_deleted(cookies, "soundcork_selected_device")
+    assert_cookie_deleted(cookies, "soundcork_selected_device_id")
+    assert_cookie_deleted(cookies, "soundcork_selected_content_item_name")
+    assert_cookie_deleted(cookies, "soundcork_selected_content_item_id")
+    assert_cookie_deleted(cookies, "soundcork_is_playing")
+
+
+def test_dashboard_clears_stale_selected_device(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.get(
+        "/miniapp/dashboard",
+        headers={
+            "Cookie": (
+                f"soundcork_account_id={ACCOUNT_ID}; "
+                "soundcork_selected_device=Bos%C3%ADk; "
+                "soundcork_selected_device_id=stale-device; "
+                "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas; "
+                "soundcork_selected_content_item_id=4; "
+                "soundcork_is_playing=true"
+            )
+        },
+    )
+
+    cookies = cookie_headers_text(response)
+    assert response.status_code == 200
+    assert "Bosík" not in response.text
+    assert "Play" not in response.text
+    assert_cookie_deleted(cookies, "soundcork_selected_device")
+    assert_cookie_deleted(cookies, "soundcork_selected_device_id")
+    assert_cookie_deleted(cookies, "soundcork_is_playing")
+
+
 def test_select_content_item_plays_when_device_is_selected(monkeypatch):
     client, speakers = make_client(monkeypatch)
 
     response = client.post(
         "/miniapp/select-content-item",
         data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
-        headers={"Cookie": f"soundcork_selected_device_id={DEVICE_ID}"},
+        headers={
+            "Cookie": (
+                f"soundcork_account_id={ACCOUNT_ID}; "
+                f"soundcork_selected_device_id={DEVICE_ID}"
+            )
+        },
         follow_redirects=False,
     )
 
@@ -136,6 +204,28 @@ def test_select_content_item_plays_when_device_is_selected(monkeypatch):
     assert speakers.play_calls == [(DEVICE_ID, "4")]
     assert "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas" in cookies
     assert "soundcork_is_playing=true" in cookies
+
+
+def test_select_content_item_ignores_stale_selected_device(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/select-content-item",
+        data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
+        headers={
+            "Cookie": (
+                f"soundcork_account_id={ACCOUNT_ID}; "
+                "soundcork_selected_device_id=stale-device"
+            )
+        },
+        follow_redirects=False,
+    )
+
+    cookies = cookie_headers_text(response)
+    assert response.status_code == 303
+    assert speakers.play_calls == []
+    assert "soundcork_selected_content_item_name=R%C3%A1dio%20Proglas" in cookies
+    assert_cookie_deleted(cookies, "soundcork_selected_device_id")
 
 
 def test_select_content_item_without_device_only_selects(monkeypatch):
@@ -160,7 +250,12 @@ def test_select_content_item_records_failed_playback(monkeypatch):
     response = client.post(
         "/miniapp/select-content-item",
         data={"content_item_id": "4", "content_item_name": "Rádio Proglas"},
-        headers={"Cookie": f"soundcork_selected_device_id={DEVICE_ID}"},
+        headers={
+            "Cookie": (
+                f"soundcork_account_id={ACCOUNT_ID}; "
+                f"soundcork_selected_device_id={DEVICE_ID}"
+            )
+        },
         follow_redirects=False,
     )
 


### PR DESCRIPTION
## Summary

- Clear miniapp device/content/playback selection cookies when a user logs in.
- Ignore and clear selected device cookies when the selected device is no longer playable for the current account.
- Ignore and clear selected content cookies when the selected item no longer exists in the current account's presets.
- Add regression coverage for stale device cookies and the existing Unicode cookie behavior.

## Why

The miniapp stores the selected device and content item in browser cookies. Those cookies can outlive the device/account state they came from. In practice, this can happen after switching accounts, removing a device, moving between Soundcork instances served from the same local hostname, or when a previously selected speaker is no longer online/in Soundcork. Before this change, the dashboard could still display the stale selected device and the Play/preset actions would attempt playback on a device ID that is not available in the current instance.

## Implementation

- Treat a selected device as valid only when it belongs to the current account, is online, is in Soundcork, and uses the Soundcork marge server.
- Reconcile selected device and selected content cookies while rendering the dashboard, so the UI no longer shows stale state or a usable Play button for an unavailable device.
- Validate selected device state again in `select-content-item`, `play`, and `stop` before issuing speaker actions.
- Keep preset selection useful even when the previous device is stale: the content item is still selected, but the stale device cookies are cleared and no playback attempt is made.

## Tests

- `uv run python -m pytest soundcork/tests/test_miniapp.py -q`
- Result: `8 passed`, with one existing Pydantic deprecation warning from `soundcork/ui/speakers.py`.

## Compatibility / Risk

This is intentionally server-side and does not require JavaScript or template changes. Users may need to reselect a device after login or after the selected device is no longer available, but that is preferable to showing stale UI state and sending no-op playback requests.

## Non-Goals

- This does not change device discovery or account association behavior.
- This does not add cross-site synchronization of miniapp selections.
- This does not alter how presets are stored or rendered.
