### PR TITLE
Handle top-level TuneIn audio browse items

### DIFF
--- a/soundcork/bmx.py
+++ b/soundcork/bmx.py
@@ -351,10 +351,10 @@ def tunein_sections_ashx(
     for idx, item in enumerate(body):
         type = item.get("type", "")
         if type:
-            # i only saw top-level items that were of type "link"; "audio" items seemed
-            # only to be included as chlidren of subsections.
             if type == "link":
                 items.append(tunein_navigate_link(item))
+            elif type == "audio":
+                items.append(tunein_navigate_playitem(item))
             else:
                 logger.info(f"top-level item has type {type}: {item}")
         else:
@@ -416,16 +416,30 @@ def tunein_sections_ashx(
     return sections
 
 
+def tunein_item_guide_id(item: dict) -> str:
+    guide_id = item.get("guide_id", "")
+    if guide_id:
+        return guide_id
+
+    tune_url = item.get("URL", "")
+    if not tune_url:
+        return ""
+
+    tune_query = urllib.parse.parse_qs(urllib.parse.urlsplit(tune_url).query)
+    return tune_query.get("id", [""])[0]
+
+
 def tunein_navigate_playitem(item: dict) -> BmxNavItem:
+    guide_id = tunein_item_guide_id(item)
     return BmxNavItem(
         links={
             "bmx_playback": {
-                "href": f'/v1/playback/station/{item.get("guide_id", "")}',
+                "href": f"/v1/playback/station/{guide_id}",
                 "type": "stationurl",
             },
             "bmx_preset": {
                 "container_art": item.get("image", ""),
-                "href": f'{item.get("guide_id", "")}',
+                "href": guide_id,
                 "name": item.get("text", ""),
                 "type": "stationurl",
             },

--- a/soundcork/tests/test_bmx.py
+++ b/soundcork/tests/test_bmx.py
@@ -57,6 +57,42 @@ def test_navigate_uses_ashx_parser_for_opml_browse_urls(monkeypatch):
     )
 
 
+def test_navigate_uses_top_level_ashx_audio_items(monkeypatch):
+    tunein_uri = "http://opml.radiotime.com/Browse.ashx?id=r101232&filter=s%3Apopular&render=json"
+    image_url = "http://cdn-radiotime-logos.tunein.com/s15666q.png"
+    requested_urls = []
+
+    def fake_urlopen(url):
+        requested_urls.append(url)
+        return FakeTuneInResponse(
+            {
+                "head": {"title": "Most Popular - Czech Republic"},
+                "body": [
+                    {
+                        "type": "audio",
+                        "text": "Evropa 2",
+                        "subtext": "Praha, Czech Republic",
+                        "image": image_url,
+                        "URL": "http://opml.radiotime.com/Tune.ashx?id=s15666&filter=s:popular",
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr("soundcork.bmx.urllib.request.urlopen", fake_urlopen)
+
+    response = tunein_navigate_v1(encode_uri(tunein_uri))
+    item = response.bmx_sections[0].items[0]
+
+    assert requested_urls == [tunein_uri]
+    assert response.bmx_sections[0].name == "Most Popular - Czech Republic"
+    assert item.name == "Evropa 2"
+    assert item.image_url == image_url
+    assert item.links.bmx_playback.href == "/v1/playback/station/s15666"
+    assert item.links.bmx_preset.href == "s15666"
+    assert item.links.bmx_preset.container_art == image_url
+
+
 def test_search_url_encodes_spaces_and_more_link_uses_encoded_query(monkeypatch):
     requested_urls = []
 


### PR DESCRIPTION
## Summary

- Handle OPML `Browse.ashx` responses where TuneIn returns station entries as top-level `audio` items.
- Extract the station guide id from `Tune.ashx?id=...` when a browse item does not include `guide_id`.
- Add a regression test covering a flat top-level `audio` browse response with station artwork and playback/preset links.

## Rationale

Some TuneIn browse pages do not return only top-level category links or subsection objects with child stations. They can return a flat list of top-level `audio` station items instead.

The previous parser logged and skipped those top-level `audio` items, so those browse pages appeared empty or incomplete in the Stockholm/BMX navigation flow. Because the skipped items also carried station images, the UI lost station artwork there as well.

## Implementation

`tunein_sections_ashx()` now treats top-level `audio` items the same way it already treats subsection child audio items.

Top-level audio items may not include `guide_id`, but their `URL` usually points at TuneIn's `Tune.ashx?id=...` endpoint. `tunein_navigate_playitem()` now uses a small helper to fall back to that query parameter, preserving playback and preset hrefs.

## Validation

Ran:

```bash
PYTHONDONTWRITEBYTECODE=1 PYTEST_ADDOPTS='--no-cov -p no:cacheprovider' /home/hideo/opensource/soundcork-live/.venv/bin/python -m pytest soundcork/tests/test_bmx.py
PYTHONDONTWRITEBYTECODE=1 /home/hideo/opensource/soundcork-live/.venv/bin/black --check --target-version py312 soundcork/bmx.py soundcork/tests/test_bmx.py
PYTHONDONTWRITEBYTECODE=1 /home/hideo/opensource/soundcork-live/.venv/bin/isort --check-only soundcork/bmx.py soundcork/tests/test_bmx.py
```

Results:

- `soundcork/tests/test_bmx.py`: 3 passed
- `black --check`: 2 files would be left unchanged
- `isort --check-only`: passed

I also verified the behavior against a local SoundCork instance using a TuneIn `Browse.ashx` popular-stations page. The response now contained station items with `imageUrl` values and `_links.bmx_playback` entries.

## Compatibility

This keeps the existing handling for top-level `link` items and subsection child items unchanged. The new guide-id fallback is only used when `guide_id` is absent and an item has a TuneIn URL with an `id` query parameter.
