### PR TITLE
Improve miniapp preset playback state

### DIFF
--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -88,6 +88,78 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         logger.error(f"Failed to start playback from {log_context}")
         return False
 
+    def is_actionable_device(combined_device) -> bool:
+        return (
+            combined_device.online
+            and combined_device.in_soundcork
+            and (combined_device.marge_server == "Soundcork")
+        )
+
+    def resolve_selected_device(
+        account_id: str,
+        selected_device_id: str | None,
+        *,
+        combined_devices: dict | None = None,
+    ):
+        if not selected_device_id:
+            return None
+
+        candidate_devices = (
+            combined_devices if combined_devices is not None else speakers.all_devices()
+        )
+        combined_device = candidate_devices.get(selected_device_id)
+        if not combined_device or combined_device.account != account_id:
+            logger.warning(
+                "Ignoring miniapp selected device %s outside account %s",
+                selected_device_id,
+                account_id,
+            )
+            return None
+
+        if not is_actionable_device(combined_device):
+            logger.warning(
+                "Ignoring miniapp selected device %s because it is not actionable",
+                selected_device_id,
+            )
+            return None
+
+        return combined_device
+
+    def get_account_presets(account_id: str):
+        try:
+            return datastore.get_presets(account_id)
+        except Exception as e:
+            logger.warning(f"Error getting presets for account {account_id}: {e}")
+            return []
+
+    def resolve_selected_preset(presets, selected_content_item_id: str | None):
+        if not selected_content_item_id:
+            return None
+
+        selected_preset = next(
+            (
+                preset
+                for preset in presets
+                if str(preset.id) == selected_content_item_id
+            ),
+            None,
+        )
+        if not selected_preset:
+            logger.warning(
+                "Ignoring unknown miniapp content item %s",
+                selected_content_item_id,
+            )
+        return selected_preset
+
+    def dashboard_redirect(params: dict[str, str] | None = None) -> RedirectResponse:
+        if not params:
+            return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+
+        return RedirectResponse(
+            url=f"/miniapp/dashboard?{urllib.parse.urlencode(params)}",
+            status_code=303,
+        )
+
     @router.get("/miniapp", response_class=HTMLResponse)
     async def main_page(request: Request):
         """Redirect to login or dashboard based on session."""
@@ -241,19 +313,18 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 if cd.account == account_id
             }
 
+            selected_device = resolve_selected_device(
+                account_id,
+                selected_device_id,
+                combined_devices=my_combined_devices,
+            )
+            selected_device_id = selected_device.id if selected_device else None
+
             devices: list[dict[str, str]] = []
-            try:
-                presets = datastore.get_presets(account_id)
-            except Exception as e:
-                logger.warning(f"Error getting presets for account {account_id}: {e}")
-                presets = []
-            selected_preset = next(
-                (
-                    preset
-                    for preset in presets
-                    if str(preset.id) == selected_content_item_id
-                ),
-                None,
+            presets = get_account_presets(account_id)
+            selected_preset = resolve_selected_preset(presets, selected_content_item_id)
+            selected_content_item_id = (
+                str(selected_preset.id) if selected_preset else None
             )
             show_started_state = use_started_state(started, started_at)
 
@@ -279,11 +350,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                     online = "offline"
                     cd = my_combined_devices[device_id]
                     device_info = datastore.get_device_info(account_id, device_id)
-                    if (
-                        cd.online
-                        and cd.in_soundcork
-                        and (cd.marge_server == "Soundcork")
-                    ):
+                    if is_actionable_device(cd):
                         online = "online"
                     devices.append(
                         {
@@ -397,22 +464,32 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             ):
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
+            account_id = request.cookies.get("soundcork_account_id", "")
+            if not account_id or not datastore.account_exists(account_id):
+                return RedirectResponse(url="/miniapp/login", status_code=303)
+
+            presets = get_account_presets(account_id)
+            selected_preset = resolve_selected_preset(presets, content_item_id)
+            if not selected_preset:
+                return dashboard_redirect()
+
+            content_item_id = str(selected_preset.id)
             params: dict[str, str] = {"selected_content_item_id": content_item_id}
-            if selected_device_id:
-                params["selected_device_id"] = selected_device_id
+            selected_device = resolve_selected_device(account_id, selected_device_id)
+            if selected_device:
+                params["selected_device_id"] = selected_device.id
                 if play_selected_content_item(
-                    selected_device_id,
+                    selected_device.id,
                     content_item_id,
                     log_context="preset click",
                 ):
                     params["started"] = "true"
                     params["started_at"] = f"{time.time():.3f}"
-            qs = urllib.parse.urlencode(params)
-            return RedirectResponse(url=f"/miniapp/dashboard?{qs}", status_code=303)
+            return dashboard_redirect(params)
 
         except Exception as e:
             logger.error(f"Error selecting content_item: {e}")
-            return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            return dashboard_redirect()
 
     @router.post("/miniapp/select-device")
     async def select_device(
@@ -432,16 +509,25 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             ):
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
-            params: dict[str, str] = {"selected_device_id": str(device_id)}
-            if selected_content_item_id:
-                params["selected_content_item_id"] = selected_content_item_id
-            qs = urllib.parse.urlencode(params)
-            logger.info(f"Device selected: {device_name} ({device_id})")
-            return RedirectResponse(url=f"/miniapp/dashboard?{qs}", status_code=303)
+            account_id = request.cookies.get("soundcork_account_id", "")
+            if not account_id or not datastore.account_exists(account_id):
+                return RedirectResponse(url="/miniapp/login", status_code=303)
+
+            selected_device = resolve_selected_device(account_id, str(device_id))
+            if not selected_device:
+                return dashboard_redirect()
+
+            params: dict[str, str] = {"selected_device_id": selected_device.id}
+            presets = get_account_presets(account_id)
+            selected_preset = resolve_selected_preset(presets, selected_content_item_id)
+            if selected_preset:
+                params["selected_content_item_id"] = str(selected_preset.id)
+            logger.info(f"Device selected: {device_name} ({selected_device.id})")
+            return dashboard_redirect(params)
 
         except Exception as e:
             logger.error(f"Error selecting device: {e}")
-            return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            return dashboard_redirect()
 
     @router.post("/miniapp/play")
     async def play(
@@ -453,7 +539,27 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         try:
             if not selected_content_item_id or not selected_device_id:
                 logger.warning("Cannot play: content_item or device not selected")
-                return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+                return dashboard_redirect()
+
+            account_id = request.cookies.get("soundcork_account_id", "")
+            if not account_id or not datastore.account_exists(account_id):
+                return RedirectResponse(url="/miniapp/login", status_code=303)
+
+            selected_device = resolve_selected_device(account_id, selected_device_id)
+            presets = get_account_presets(account_id)
+            selected_preset = resolve_selected_preset(presets, selected_content_item_id)
+            params: dict[str, str] = {}
+            if selected_device:
+                selected_device_id = selected_device.id
+                params["selected_device_id"] = selected_device_id
+            if selected_preset:
+                selected_content_item_id = str(selected_preset.id)
+                params["selected_content_item_id"] = selected_content_item_id
+            if not selected_device or not selected_preset:
+                logger.warning(
+                    "Cannot play: selected device or content item is invalid"
+                )
+                return dashboard_redirect(params)
 
             started = play_selected_content_item(
                 selected_device_id,
@@ -461,21 +567,14 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 log_context="play button",
             )
 
-            params = {
-                "selected_device_id": selected_device_id,
-                "selected_content_item_id": selected_content_item_id,
-            }
             if started:
                 params["started"] = "true"
                 params["started_at"] = f"{time.time():.3f}"
-            return RedirectResponse(
-                url=f"/miniapp/dashboard?{urllib.parse.urlencode(params)}",
-                status_code=303,
-            )
+            return dashboard_redirect(params)
 
         except Exception as e:
             logger.error(f"Error in play endpoint: {e}")
-            return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            return dashboard_redirect()
 
     @router.post("/miniapp/stop")
     async def stop(
@@ -487,7 +586,24 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         try:
             if not selected_device_id:
                 logger.warning("Cannot stop: device not selected")
-                return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+                return dashboard_redirect()
+
+            account_id = request.cookies.get("soundcork_account_id", "")
+            if not account_id or not datastore.account_exists(account_id):
+                return RedirectResponse(url="/miniapp/login", status_code=303)
+
+            selected_device = resolve_selected_device(account_id, selected_device_id)
+            presets = get_account_presets(account_id)
+            selected_preset = resolve_selected_preset(presets, selected_content_item_id)
+            params: dict[str, str] = {}
+            if selected_device:
+                selected_device_id = selected_device.id
+                params["selected_device_id"] = selected_device_id
+            if selected_preset:
+                params["selected_content_item_id"] = str(selected_preset.id)
+            if not selected_device:
+                logger.warning("Cannot stop: selected device is invalid")
+                return dashboard_redirect(params)
 
             # Stop playback
             success = speakers.stop_playback(selected_device_id)
@@ -496,12 +612,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             else:
                 logger.error("Failed to stop playback")
 
-            params: dict[str, str] = {
-                "selected_device_id": selected_device_id,
-                "stopped": "true",
-            }
-            if selected_content_item_id:
-                params["selected_content_item_id"] = selected_content_item_id
+            params["stopped"] = "true"
             return RedirectResponse(
                 url=f"/miniapp/dashboard?{urllib.parse.urlencode(params)}",
                 status_code=303,
@@ -509,7 +620,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
 
         except Exception as e:
             logger.error(f"Error in stop endpoint: {e}")
-            return RedirectResponse(url="/miniapp/dashboard", status_code=303)
+            return dashboard_redirect()
 
     @router.post("/miniapp/logout")
     async def logout(request: Request):

--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -4,6 +4,7 @@ Endpoints for a miniapp UI.
 
 import asyncio
 import logging
+import time
 import urllib.parse
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -23,6 +24,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 NOW_PLAYING_TIMEOUT = 3.0
+STARTED_OPTIMISTIC_SECONDS = 3.0
 
 
 @dataclass
@@ -57,10 +59,34 @@ def get_device_image(product_code: str) -> str:
     return DEVICE_IMAGE_MAP.get(product_code.lower(), DEFAULT_DEVICE_IMAGE)
 
 
+def use_started_state(started: bool, started_at: float | None) -> bool:
+    """Return True while a just-started playback action may still have stale metadata."""
+    if not started or started_at is None:
+        return False
+
+    elapsed = time.time() - started_at
+    return 0 <= elapsed <= STARTED_OPTIMISTIC_SECONDS
+
+
 def get_miniapp_router(datastore: DataStore, speakers: Speakers):
     templates = Jinja2Templates(directory="templates")
 
     router = APIRouter(tags=["miniapp"])
+
+    def play_selected_content_item(
+        device_id: str,
+        content_item_id: str,
+        *,
+        log_context: str,
+    ) -> bool:
+        if speakers.play_content_item(device_id, content_item_id):
+            logger.info(
+                f"Started playback from {log_context}: content_item {content_item_id} on device {device_id}"
+            )
+            return True
+
+        logger.error(f"Failed to start playback from {log_context}")
+        return False
 
     @router.get("/miniapp", response_class=HTMLResponse)
     async def main_page(request: Request):
@@ -163,6 +189,8 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         request: Request,
         selected_content_item_id: str | None = Query(None),
         selected_device_id: str | None = Query(None),
+        started: bool = Query(False),
+        started_at: float | None = Query(None),
         stopped: bool = Query(False),
     ):
         """Display dashboard with devices and presets.
@@ -175,6 +203,13 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
 
             selected_device_id: The speaker, if one is selected
                 in the user's context.
+
+            started: If playback on the current device was just started
+                by the user's request. Passing as an argument to avoid
+                timing issues in the query.
+
+            started_at: Server timestamp for the playback start redirect. Keeps
+                the optimistic started state short-lived if the page is reloaded.
 
             stopped: If the stream on the current device was just stopped
                 by the user's request. Passing as an argument to avoid
@@ -207,7 +242,20 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             }
 
             devices: list[dict[str, str]] = []
-            presets: list["Preset"] = []
+            try:
+                presets = datastore.get_presets(account_id)
+            except Exception as e:
+                logger.warning(f"Error getting presets for account {account_id}: {e}")
+                presets = []
+            selected_preset = next(
+                (
+                    preset
+                    for preset in presets
+                    if str(preset.id) == selected_content_item_id
+                ),
+                None,
+            )
+            show_started_state = use_started_state(started, started_at)
 
             for device_id in my_combined_devices.keys():
                 try:
@@ -215,6 +263,19 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                         np = NowPlaying("", "", "", 0, 0, False)
                     else:
                         np = await _get_now_playing(device_id)
+                        if (
+                            show_started_state
+                            and device_id == selected_device_id
+                            and selected_preset
+                        ):
+                            np = NowPlaying(
+                                selected_preset.name,
+                                selected_preset.container_art or "",
+                                "PLAY_STATE",
+                                np.volume_actual,
+                                np.volume_target,
+                                np.is_muted,
+                            )
                     online = "offline"
                     cd = my_combined_devices[device_id]
                     device_info = datastore.get_device_info(account_id, device_id)
@@ -238,14 +299,6 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                             "now_playing_is_muted": str(np.is_muted),
                         }
                     )
-
-                    if not presets:
-                        try:
-                            presets = datastore.get_presets(account_id)
-                        except Exception as e:
-                            logger.warning(
-                                f"Error getting presets for device {device_id}: {e}"
-                            )
 
                 except Exception as e:
                     logger.error(f"Error getting device info for {device_id}: {e}")
@@ -301,8 +354,13 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             logger.warning(f"Timeout getting now playing status for {device_id}")
             return NowPlaying("[Unknown]", "", "", 0, 0, False)
 
-        if np:
+        try:
             volume = speakers.get_volume(device_id)
+        except Exception as e:
+            logger.warning(f"Error getting volume for {device_id}: {e}")
+            volume = None
+
+        if np:
             return NowPlaying(
                 f"{np.StationName or np.ContentItem.Name}",
                 np.ContainerArtUrl or "",
@@ -312,7 +370,14 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 volume.IsMuted if volume else False,
             )
         else:
-            return NowPlaying("", "", "", 0, 0, False)
+            return NowPlaying(
+                "",
+                "",
+                "",
+                volume.Actual if volume else 0,
+                volume.Target if volume else 0,
+                volume.IsMuted if volume else False,
+            )
 
     @router.post("/miniapp/select-content-item")
     async def select_content_item(
@@ -335,6 +400,13 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
             params: dict[str, str] = {"selected_content_item_id": content_item_id}
             if selected_device_id:
                 params["selected_device_id"] = selected_device_id
+                if play_selected_content_item(
+                    selected_device_id,
+                    content_item_id,
+                    log_context="preset click",
+                ):
+                    params["started"] = "true"
+                    params["started_at"] = f"{time.time():.3f}"
             qs = urllib.parse.urlencode(params)
             return RedirectResponse(url=f"/miniapp/dashboard?{qs}", status_code=303)
 
@@ -383,18 +455,19 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 logger.warning("Cannot play: content_item or device not selected")
                 return RedirectResponse(url="/miniapp/dashboard", status_code=303)
 
-            # Play the content_item
-            if speakers.play_content_item(selected_device_id, selected_content_item_id):
-                logger.info(
-                    f"Started playback: content_item {selected_content_item_id} on device {selected_device_id}"
-                )
-            else:
-                logger.error("Failed to start playback")
+            started = play_selected_content_item(
+                selected_device_id,
+                selected_content_item_id,
+                log_context="play button",
+            )
 
             params = {
                 "selected_device_id": selected_device_id,
                 "selected_content_item_id": selected_content_item_id,
             }
+            if started:
+                params["started"] = "true"
+                params["started_at"] = f"{time.time():.3f}"
             return RedirectResponse(
                 url=f"/miniapp/dashboard?{urllib.parse.urlencode(params)}",
                 status_code=303,

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -14,6 +14,7 @@ from soundcork.model import Preset
 
 ACCOUNT_ID = "8208423"
 DEVICE_ID = "device-1"
+CONTENT_ITEM_ID = "4"
 STARTED_AT = 1000.0
 STARTED_AT_QUERY = "1000"
 
@@ -69,24 +70,36 @@ class FakeSpeakers:
         self,
         play_result: bool = True,
         now_playing_status=None,
+        online: bool = True,
+        in_soundcork: bool = True,
+        marge_server: str = "Soundcork",
     ) -> None:
         self.play_result = play_result
         self.now_playing_status = now_playing_status
+        self.online = online
+        self.in_soundcork = in_soundcork
+        self.marge_server = marge_server
         self.play_calls: list[tuple[str, str]] = []
+        self.stop_calls: list[str] = []
 
     def all_devices(self):
         return {
             DEVICE_ID: SimpleNamespace(
+                id=DEVICE_ID,
                 account=ACCOUNT_ID,
-                online=True,
-                in_soundcork=True,
-                marge_server="Soundcork",
+                online=self.online,
+                in_soundcork=self.in_soundcork,
+                marge_server=self.marge_server,
             )
         }
 
     def play_content_item(self, device_id: str, content_item_id: str) -> bool:
         self.play_calls.append((device_id, content_item_id))
         return self.play_result
+
+    def stop_playback(self, device_id: str) -> bool:
+        self.stop_calls.append(device_id)
+        return True
 
     def get_now_playing_status(self, device_id: str):
         assert device_id == DEVICE_ID
@@ -130,22 +143,95 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
     assert "Rádio Proglas" in response.text
 
 
+def test_dashboard_ignores_stale_selected_device(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id=stale-device&selected_content_item_id={CONTENT_ITEM_ID}"
+    )
+
+    assert response.status_code == 200
+    assert "No speaker selected." in response.text
+    assert "Selected audio source: Rádio Proglas" in response.text
+
+
+def test_dashboard_ignores_unknown_selected_content_item(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=stale-content"
+    )
+
+    assert response.status_code == 200
+    assert "Selected speaker: ložnice" in response.text
+    assert "No preset selected." in response.text
+
+
+def test_dashboard_ignores_non_actionable_selected_device(monkeypatch):
+    speakers = FakeSpeakers(online=False)
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}"
+    )
+
+    assert response.status_code == 200
+    assert "No speaker selected." in response.text
+    assert "Selected audio source: Rádio Proglas" in response.text
+
+
 def test_play_redirect_marks_just_started(monkeypatch):
     monkeypatch.setattr("soundcork.miniapp.time.time", lambda: 1000.1234)
     client, speakers = make_client(monkeypatch)
     client.cookies.set("soundcork_account_id", ACCOUNT_ID)
 
     response = client.post(
-        f"/miniapp/play?selected_device_id={DEVICE_ID}&selected_content_item_id=content-1",
+        f"/miniapp/play?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}",
         follow_redirects=False,
     )
 
     assert response.status_code == 303
     assert (
         response.headers["location"]
-        == f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=content-1&started=true&started_at=1000.123"
+        == f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}&started=true&started_at=1000.123"
     )
-    assert speakers.play_calls == [(DEVICE_ID, "content-1")]
+    assert speakers.play_calls == [(DEVICE_ID, CONTENT_ITEM_ID)]
+
+
+def test_play_ignores_stale_selected_device(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        f"/miniapp/play?selected_device_id=stale-device&selected_content_item_id={CONTENT_ITEM_ID}",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_content_item_id={CONTENT_ITEM_ID}"
+    )
+    assert speakers.play_calls == []
+
+
+def test_play_ignores_unknown_selected_content_item(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        f"/miniapp/play?selected_device_id={DEVICE_ID}&selected_content_item_id=stale-content",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == (
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}"
+    )
+    assert speakers.play_calls == []
 
 
 def test_select_content_item_plays_when_device_is_selected(monkeypatch):
@@ -155,33 +241,87 @@ def test_select_content_item_plays_when_device_is_selected(monkeypatch):
 
     response = client.post(
         f"/miniapp/select-content-item?selected_device_id={DEVICE_ID}",
-        data={"content_item_id": "content-1", "content_item_name": "Radio preset"},
+        data={"content_item_id": CONTENT_ITEM_ID, "content_item_name": "Radio preset"},
         follow_redirects=False,
     )
 
     assert response.status_code == 303
     assert (
         response.headers["location"]
-        == f"/miniapp/dashboard?selected_content_item_id=content-1&selected_device_id={DEVICE_ID}&started=true&started_at=1000.123"
+        == f"/miniapp/dashboard?selected_content_item_id={CONTENT_ITEM_ID}&selected_device_id={DEVICE_ID}&started=true&started_at=1000.123"
     )
-    assert speakers.play_calls == [(DEVICE_ID, "content-1")]
+    assert speakers.play_calls == [(DEVICE_ID, CONTENT_ITEM_ID)]
+
+
+def test_select_content_item_with_stale_device_only_selects(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        "/miniapp/select-content-item?selected_device_id=stale-device",
+        data={"content_item_id": CONTENT_ITEM_ID, "content_item_name": "Radio preset"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_content_item_id={CONTENT_ITEM_ID}"
+    )
+    assert speakers.play_calls == []
 
 
 def test_select_content_item_without_device_only_selects(monkeypatch):
     client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
 
     response = client.post(
         "/miniapp/select-content-item",
-        data={"content_item_id": "content-1", "content_item_name": "Radio preset"},
+        data={"content_item_id": CONTENT_ITEM_ID, "content_item_name": "Radio preset"},
         follow_redirects=False,
     )
 
     assert response.status_code == 303
     assert (
         response.headers["location"]
-        == "/miniapp/dashboard?selected_content_item_id=content-1"
+        == f"/miniapp/dashboard?selected_content_item_id={CONTENT_ITEM_ID}"
     )
     assert speakers.play_calls == []
+
+
+def test_select_device_ignores_unknown_selected_content_item(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        "/miniapp/select-device?selected_content_item_id=stale-content",
+        data={"device_id": DEVICE_ID, "device_name": "ložnice"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_device_id={DEVICE_ID}"
+    )
+    assert speakers.play_calls == []
+
+
+def test_stop_ignores_stale_selected_device(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        f"/miniapp/stop?selected_device_id=stale-device&selected_content_item_id={CONTENT_ITEM_ID}",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_content_item_id={CONTENT_ITEM_ID}"
+    )
+    assert speakers.stop_calls == []
 
 
 def test_started_dashboard_shows_optimistic_playback_state(monkeypatch):
@@ -191,7 +331,7 @@ def test_started_dashboard_shows_optimistic_playback_state(monkeypatch):
     client.cookies.set("soundcork_account_label", "%C3%9A%C4%8Det%20lo%C5%BEnice")
 
     response = client.get(
-        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}&started=true&started_at={STARTED_AT_QUERY}"
     )
 
     assert response.status_code == 200
@@ -215,7 +355,7 @@ def test_started_dashboard_overrides_stale_playing_metadata(monkeypatch):
     client.cookies.set("soundcork_account_label", "%C3%9A%C4%8Det%20lo%C5%BEnice")
 
     response = client.get(
-        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}&started=true&started_at={STARTED_AT_QUERY}"
     )
 
     assert response.status_code == 200
@@ -238,7 +378,7 @@ def test_started_dashboard_uses_actual_metadata_after_optimistic_window(monkeypa
     client.cookies.set("soundcork_account_id", ACCOUNT_ID)
 
     response = client.get(
-        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id={CONTENT_ITEM_ID}&started=true&started_at={STARTED_AT_QUERY}"
     )
 
     assert response.status_code == 200

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -5,11 +5,25 @@ from typing import Any, cast
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from soundcork.miniapp import get_miniapp_router
+from soundcork.miniapp import (
+    STARTED_OPTIMISTIC_SECONDS,
+    get_miniapp_router,
+    use_started_state,
+)
 from soundcork.model import Preset
 
 ACCOUNT_ID = "8208423"
 DEVICE_ID = "device-1"
+STARTED_AT = 1000.0
+STARTED_AT_QUERY = "1000"
+
+
+def inside_started_window() -> float:
+    return STARTED_AT + STARTED_OPTIMISTIC_SECONDS / 2
+
+
+def outside_started_window() -> float:
+    return STARTED_AT + STARTED_OPTIMISTIC_SECONDS + 1.0
 
 
 class FakeDatastore:
@@ -51,8 +65,13 @@ class FakeDatastore:
 
 
 class FakeSpeakers:
-    def __init__(self, play_result: bool = True) -> None:
+    def __init__(
+        self,
+        play_result: bool = True,
+        now_playing_status=None,
+    ) -> None:
         self.play_result = play_result
+        self.now_playing_status = now_playing_status
         self.play_calls: list[tuple[str, str]] = []
 
     def all_devices(self):
@@ -68,6 +87,14 @@ class FakeSpeakers:
     def play_content_item(self, device_id: str, content_item_id: str) -> bool:
         self.play_calls.append((device_id, content_item_id))
         return self.play_result
+
+    def get_now_playing_status(self, device_id: str):
+        assert device_id == DEVICE_ID
+        return self.now_playing_status
+
+    def get_volume(self, device_id: str):
+        assert device_id == DEVICE_ID
+        return SimpleNamespace(Actual=23, Target=23, IsMuted=False)
 
 
 def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
@@ -99,3 +126,133 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
 
     assert response.status_code == 200
     assert "Účet ložnice" in response.text
+    assert "ložnice" in response.text
+    assert "Rádio Proglas" in response.text
+
+
+def test_play_redirect_marks_just_started(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", lambda: 1000.1234)
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        f"/miniapp/play?selected_device_id={DEVICE_ID}&selected_content_item_id=content-1",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=content-1&started=true&started_at=1000.123"
+    )
+    assert speakers.play_calls == [(DEVICE_ID, "content-1")]
+
+
+def test_select_content_item_plays_when_device_is_selected(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", lambda: 1000.1234)
+    client, speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.post(
+        f"/miniapp/select-content-item?selected_device_id={DEVICE_ID}",
+        data={"content_item_id": "content-1", "content_item_name": "Radio preset"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == f"/miniapp/dashboard?selected_content_item_id=content-1&selected_device_id={DEVICE_ID}&started=true&started_at=1000.123"
+    )
+    assert speakers.play_calls == [(DEVICE_ID, "content-1")]
+
+
+def test_select_content_item_without_device_only_selects(monkeypatch):
+    client, speakers = make_client(monkeypatch)
+
+    response = client.post(
+        "/miniapp/select-content-item",
+        data={"content_item_id": "content-1", "content_item_name": "Radio preset"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert (
+        response.headers["location"]
+        == "/miniapp/dashboard?selected_content_item_id=content-1"
+    )
+    assert speakers.play_calls == []
+
+
+def test_started_dashboard_shows_optimistic_playback_state(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", inside_started_window)
+    client, _speakers = make_client(monkeypatch)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+    client.cookies.set("soundcork_account_label", "%C3%9A%C4%8Det%20lo%C5%BEnice")
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+    )
+
+    assert response.status_code == 200
+    assert "Now Playing on ložnice" in response.text
+    assert "Rádio Proglas" in response.text
+    assert "Volume: 23" in response.text
+    assert "Stop" in response.text
+
+
+def test_started_dashboard_overrides_stale_playing_metadata(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", inside_started_window)
+    stale_now_playing = SimpleNamespace(
+        StationName="CRo D-dur",
+        ContentItem=SimpleNamespace(Name="CRo D-dur"),
+        ContainerArtUrl="http://example.com/ddur.png",
+        PlayStatus="PLAY_STATE",
+    )
+    speakers = FakeSpeakers(now_playing_status=stale_now_playing)
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+    client.cookies.set("soundcork_account_label", "%C3%9A%C4%8Det%20lo%C5%BEnice")
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+    )
+
+    assert response.status_code == 200
+    assert "Now Playing on ložnice" in response.text
+    assert "Rádio Proglas" in response.text
+    assert "CRo D-dur" not in response.text
+    assert "Stop" in response.text
+
+
+def test_started_dashboard_uses_actual_metadata_after_optimistic_window(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", outside_started_window)
+    stale_now_playing = SimpleNamespace(
+        StationName="CRo D-dur",
+        ContentItem=SimpleNamespace(Name="CRo D-dur"),
+        ContainerArtUrl="http://example.com/ddur.png",
+        PlayStatus="PLAY_STATE",
+    )
+    speakers = FakeSpeakers(now_playing_status=stale_now_playing)
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+    client.cookies.set("soundcork_account_id", ACCOUNT_ID)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}&selected_content_item_id=4&started=true&started_at={STARTED_AT_QUERY}"
+    )
+
+    assert response.status_code == 200
+    assert "CRo D-dur" in response.text
+
+
+def test_use_started_state_is_short_lived(monkeypatch):
+    monkeypatch.setattr("soundcork.miniapp.time.time", inside_started_window)
+
+    assert use_started_state(True, STARTED_AT)
+    assert not use_started_state(True, STARTED_AT - STARTED_OPTIMISTIC_SECONDS)
+    assert not use_started_state(True, None)
+    assert not use_started_state(False, STARTED_AT)
+
+
+def test_started_optimistic_window_is_three_seconds():
+    assert STARTED_OPTIMISTIC_SECONDS == 3.0


### PR DESCRIPTION
## Summary

- Start playback immediately when a miniapp preset is clicked and a speaker is already selected.
- Keep the existing Play button path consistent with preset-click playback.
- Add a short-lived just-started display state so the now-playing panel does not briefly show stale speaker metadata after a successful start request.
- Validate miniapp selected device/content query state before rendering selected controls or sending speaker commands.

## Rationale

After the now-playing miniapp update, selecting a preset could update the selected source without immediately updating the now-playing controls. In practice the speaker can also report `PLAY_STATE` with the previous station for a short time after the new stream has already started, which makes the dashboard show mismatched values such as a new selected source beside stale now-playing metadata.

The miniapp now carries selected state in query parameters. That makes stale or manually edited `selected_device_id` / `selected_content_item_id` values possible, so the selected state needs to be validated before the UI treats it as actionable.

## Implementation Details

- Added a shared `play_selected_content_item()` helper used by both preset-click and Play-button actions.
- When a preset is clicked with a valid `selected_device_id` present, the miniapp now starts that content item instead of only selecting it.
- Successful start redirects include `started=true` and a server-side `started_at` timestamp.
- The dashboard treats the selected preset as authoritative for the selected speaker for three seconds after a start action, then falls back to the speaker's actual now-playing response.
- Volume is still read from the speaker, including during the short optimistic display window.
- Added shared validation helpers for account-scoped, actionable selected devices and known selected presets.
- `dashboard`, `select-content-item`, `select-device`, `play`, and `stop` now drop stale selected state instead of passing invalid IDs to speaker commands or optimistic UI state.

## Tests / Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m black --check --target-version py312 soundcork/miniapp.py soundcork/tests/test_miniapp.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m isort --check-only soundcork/miniapp.py soundcork/tests/test_miniapp.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest soundcork/tests/test_miniapp.py -q` passed with `17 passed`.
- `UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest soundcork/tests -q` passed with `45 passed`.
- Earlier live validation on a local UDR showed that preset clicks start playback and the Stop/volume/now-playing state updates immediately after redirect.

## Compatibility and Risk

The optimistic display state is deliberately short-lived and only applies after a successful explicit playback request. If the speaker still reports different metadata after that window, the UI shows the actual speaker response.

The selected-state validation keeps devices visible in the dashboard but only treats account-scoped, actionable devices as selected playback targets. Stale query parameters are dropped from redirects where possible, preserving any still-valid selected device or selected preset.

## Non-Goals / Follow-Ups

- This PR does not change speaker playback internals or the SoundTouch API client.
- This PR does not add group/zone display to the miniapp.
