### PR TITLE
Proxy miniapp station artwork

### DIFF
--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -9,8 +9,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import quote, unquote
 
-from fastapi import APIRouter, Query, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+import httpx
+from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from soundcork.constants import DEFAULT_DEVICE_IMAGE, DEVICE_IMAGE_MAP
@@ -23,6 +24,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 NOW_PLAYING_TIMEOUT = 3.0
+ARTWORK_PROXY_TIMEOUT = 5.0
+ARTWORK_PROXY_MAX_BYTES = 2_000_000
+ARTWORK_PROXY_HOST_SUFFIXES = ("tunein.com", "radiotime.com")
 
 
 @dataclass
@@ -57,10 +61,77 @@ def get_device_image(product_code: str) -> str:
     return DEVICE_IMAGE_MAP.get(product_code.lower(), DEFAULT_DEVICE_IMAGE)
 
 
+def should_proxy_artwork_url(url: str | None) -> bool:
+    """Return True for external artwork hosts known to need browser-safe proxying."""
+    if not url:
+        return False
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+
+    hostname = (parsed.hostname or "").lower()
+    return any(
+        hostname == suffix or hostname.endswith(f".{suffix}")
+        for suffix in ARTWORK_PROXY_HOST_SUFFIXES
+    )
+
+
+def miniapp_artwork_url(url: str | None) -> str:
+    """Return a browser-friendly artwork URL for the miniapp."""
+    if not url:
+        return ""
+
+    if not should_proxy_artwork_url(url):
+        return url
+
+    return f"/miniapp/artwork?url={quote(url, safe='')}"
+
+
 def get_miniapp_router(datastore: DataStore, speakers: Speakers):
     templates = Jinja2Templates(directory="templates")
+    templates.env.globals["miniapp_artwork_url"] = miniapp_artwork_url
 
     router = APIRouter(tags=["miniapp"])
+
+    @router.get("/miniapp/artwork")
+    async def artwork_proxy(url: str = Query(...)):
+        """Proxy selected station artwork so browsers do not block CDN images."""
+        if not should_proxy_artwork_url(url):
+            raise HTTPException(status_code=400, detail="Unsupported artwork URL")
+
+        try:
+            async with httpx.AsyncClient(
+                timeout=ARTWORK_PROXY_TIMEOUT,
+                follow_redirects=True,
+            ) as client:
+                upstream = await client.get(
+                    url,
+                    headers={"User-Agent": "SoundCork miniapp artwork proxy"},
+                )
+                upstream.raise_for_status()
+        except httpx.HTTPError as e:
+            logger.warning(f"Could not fetch miniapp artwork {url}: {e}")
+            raise HTTPException(status_code=502, detail="Artwork fetch failed") from e
+
+        content_type = (
+            upstream.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+        )
+        if not content_type.startswith("image/"):
+            logger.warning(
+                f"Miniapp artwork URL {url} returned non-image content type {content_type}"
+            )
+            raise HTTPException(status_code=502, detail="Artwork URL is not an image")
+
+        if len(upstream.content) > ARTWORK_PROXY_MAX_BYTES:
+            logger.warning(f"Miniapp artwork URL {url} returned too much data")
+            raise HTTPException(status_code=502, detail="Artwork is too large")
+
+        return Response(
+            content=upstream.content,
+            media_type=content_type,
+            headers={"Cache-Control": "public, max-age=86400"},
+        )
 
     @router.get("/miniapp", response_class=HTMLResponse)
     async def main_page(request: Request):

--- a/soundcork/templates/dashboard.html
+++ b/soundcork/templates/dashboard.html
@@ -70,7 +70,7 @@
                             <input type="hidden" name="content_item_name" value="{{ preset.name }}">
                             <button type="submit" class="preset-card">
                                 {% if preset.container_art %}
-                                <img src="{{ preset.container_art }}" alt="">
+                                <img src="{{ miniapp_artwork_url(preset.container_art) }}" alt="">
                                 {% endif %}
                                 <span class="preset-number">{{ preset.id }}</span>
                                 <span class="preset-name">{{ preset.name }}</span>
@@ -127,7 +127,7 @@
                 <p>Now Playing on {{ ns.selected_device_obj.name }}:<br>
                     {{ ns.selected_device_obj.now_playing }}</p>
                 {% if ns.selected_device_obj.now_playing_image %}
-                <img alt="" src="{{  ns.selected_device_obj.now_playing_image }}" width=100px;>
+                <img alt="" src="{{ miniapp_artwork_url(ns.selected_device_obj.now_playing_image) }}" width=100px;>
                 {% endif %}
                 {# TODO: right now this is read-only #}
                 <p><input type="range" min="1" max="100" value={{ ns.selected_device_obj.now_playing_volume }}
@@ -140,8 +140,8 @@
             <div class="content-item-info">
                 {% if ns.selected_preset_obj %}
                 Selected audio source: {{ ns.selected_preset_obj.name }}
-                {% if ns.selected_preset_obj.now_playing_image %}
-                <img alt="" src="{{  ns.selected_preset_obj.container_art }}" width=100px;>
+                {% if ns.selected_preset_obj.container_art %}
+                <img alt="" src="{{ miniapp_artwork_url(ns.selected_preset_obj.container_art) }}" width=100px;>
                 {% endif %}
                 {% else %}
                 No preset selected.

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from soundcork.miniapp import get_miniapp_router
+from soundcork.miniapp import get_miniapp_router, miniapp_artwork_url
 from soundcork.model import Preset
 
 ACCOUNT_ID = "8208423"
@@ -13,6 +13,9 @@ DEVICE_ID = "device-1"
 
 
 class FakeDatastore:
+    def __init__(self, container_art: str = "") -> None:
+        self.container_art = container_art
+
     def account_exists(self, account_id: str) -> bool:
         return account_id == ACCOUNT_ID
 
@@ -45,7 +48,7 @@ class FakeDatastore:
                 source="LOCAL_INTERNET_RADIO",
                 type="STORED_MUSIC",
                 location="proglas",
-                container_art="",
+                container_art=self.container_art,
             )
         ]
 
@@ -69,13 +72,22 @@ class FakeSpeakers:
         self.play_calls.append((device_id, content_item_id))
         return self.play_result
 
+    def get_now_playing_status(self, device_id: str):
+        assert device_id == DEVICE_ID
+        return None
 
-def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
+
+def make_client(
+    monkeypatch,
+    speakers: FakeSpeakers | None = None,
+    datastore: FakeDatastore | None = None,
+):
     monkeypatch.chdir(Path(__file__).resolve().parents[1])
     app = FastAPI()
     fake_speakers = speakers or FakeSpeakers()
+    fake_datastore = datastore or FakeDatastore()
     app.include_router(
-        get_miniapp_router(cast(Any, FakeDatastore()), cast(Any, fake_speakers))
+        get_miniapp_router(cast(Any, fake_datastore), cast(Any, fake_speakers))
     )
     return TestClient(app), fake_speakers
 
@@ -99,3 +111,72 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
 
     assert response.status_code == 200
     assert "Účet ložnice" in response.text
+
+
+def test_dashboard_proxies_tunein_preset_art(monkeypatch):
+    art_url = "http://cdn-profiles.tunein.com/s123/images/logoq.png?t=1"
+    client, _speakers = make_client(
+        monkeypatch,
+        datastore=FakeDatastore(container_art=art_url),
+    )
+
+    response = client.get(
+        "/miniapp/dashboard?selected_content_item_id=4",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert f'src="{miniapp_artwork_url(art_url)}"' in response.text
+
+
+def test_miniapp_artwork_url_proxies_only_tunein_artwork():
+    tunein_art = "http://cdn-radiotime-logos.tunein.com/s15666q.png"
+    other_art = "https://i.scdn.co/image/example"
+
+    assert miniapp_artwork_url(tunein_art).startswith("/miniapp/artwork?url=")
+    assert miniapp_artwork_url(other_art) == other_art
+
+
+def test_artwork_proxy_rejects_unsupported_url(monkeypatch):
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.get("/miniapp/artwork?url=http%3A%2F%2F127.0.0.1%2Fsecret.png")
+
+    assert response.status_code == 400
+
+
+def test_artwork_proxy_returns_image(monkeypatch):
+    class FakeUpstream:
+        headers = {"content-type": "Image/PNG; charset=binary"}
+        content = b"png-bytes"
+
+        def raise_for_status(self):
+            return None
+
+    class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get(self, url, headers):
+            assert url == "http://cdn-profiles.tunein.com/s123/logo.png"
+            assert headers["User-Agent"] == "SoundCork miniapp artwork proxy"
+            return FakeUpstream()
+
+    monkeypatch.setattr("soundcork.miniapp.httpx.AsyncClient", FakeAsyncClient)
+    client, _speakers = make_client(monkeypatch)
+
+    response = client.get(
+        "/miniapp/artwork?url=http%3A%2F%2Fcdn-profiles.tunein.com%2Fs123%2Flogo.png"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "image/png"
+    assert response.headers["cache-control"] == "public, max-age=86400"
+    assert response.content == b"png-bytes"


### PR DESCRIPTION
## Summary

- Add a narrow miniapp artwork proxy for TuneIn/RadioTime station images.
- Use the proxy for preset, now-playing, and selected-preset artwork in the dashboard.
- Fix the selected-preset sidebar condition so it checks `container_art` before rendering preset artwork.

## Rationale

Some browsers may block or fail to render station artwork when the miniapp embeds external TuneIn CDN image URLs directly. Serving the same artwork through the local SoundCork origin avoids that browser-specific behavior while keeping the miniapp HTML stable.

## Implementation Details

- Added `/miniapp/artwork?url=...`.
- Only `http` and `https` URLs on `tunein.com` or `radiotime.com` hostnames are proxied.
- The proxy follows redirects, checks that the upstream response is an image, enforces a 2 MB size limit, and returns `Cache-Control: public, max-age=86400`.
- There is no persistent disk cache; images are fetched and returned per request, with normal browser caching allowed by response headers.
- Dashboard templates now call `miniapp_artwork_url()` for preset cards, selected speaker now-playing artwork, and selected-preset artwork.

## Tests / Validation

- `black --check --target-version py312 soundcork/miniapp.py soundcork/tests/test_miniapp.py`
- `isort --check-only soundcork/miniapp.py soundcork/tests/test_miniapp.py`
- `python -m py_compile soundcork/miniapp.py soundcork/tests/test_miniapp.py`
- `timeout 60s /home/hideo/opensource/soundcork-live/.venv/bin/python -m pytest -q soundcork/tests/test_miniapp.py` passed with `5 passed, 1 warning` in a clean worktree based on `origin/main`.
- Live validation on a local UDR showed `/miniapp/artwork?url=http%3A%2F%2Fcdn-profiles.tunein.com%2Fs25574%2Fimages%2Flogoq.png%3Ft%3D1` returning `200 image/png`, and Firefox displayed station logos after reload.

## Compatibility and Risk

The endpoint is intentionally not a general-purpose HTTP proxy. Unsupported hosts are rejected with `400`, non-image responses with `502`, and large responses with `502`.

## Non-Goals / Follow-Ups

- This PR does not add persistent artwork storage or a server-side disk cache.
- This PR does not modify TuneIn/BMX playback behavior.
