### PR TITLE
Add management devices API

### DIFF
--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -172,12 +172,12 @@ def read_file_from_speaker_ssh(host: str, remote_path: str, local_path: str) -> 
         logger.info(f"Error: {e}")
 
 
-def read_file_from_speaker_http(host: str, path: str) -> str:
+def read_file_from_speaker_http(host: str, path: str, timeout: int = 2) -> str:
     """Read a file from the remote speaker, using their HTTP API."""
     url = f"http://{host}:{SPEAKER_HTTP_PORT}{path}"
     logger.info(f"checking {url}")
     try:
-        return str(urllib.request.urlopen(url).read(), "utf-8")
+        return str(urllib.request.urlopen(url, timeout=timeout).read(), "utf-8")
     except Exception:
         logger.info(f"no result for {url}")
         return ""

--- a/soundcork/management.py
+++ b/soundcork/management.py
@@ -15,13 +15,19 @@ SPOTIFY_CLIENT_SECRET are configured.
 #        be modified from the admin UI
 
 import logging
+import xml.etree.ElementTree as ET
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import BaseModel
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
+from soundcork.devices import get_bose_devices, hostname_for_device, read_device_info
+from soundcork.model import DeviceInfo
 from soundcork.spotify_service import SpotifyService
 
 logger = logging.getLogger(__name__)
@@ -31,6 +37,294 @@ router = APIRouter(prefix="/mgmt", tags=["management"])
 datastore = DataStore()
 settings = Settings()
 spotify = SpotifyService()
+
+BOSE_MARGE_URL = "https://streaming.bose.com"
+
+
+class ManagementDevice(BaseModel):
+    """Sanitized management view of a SoundTouch speaker."""
+
+    device_id: str
+    account_id: str | None = None
+    reported_account_id: str | None = None
+    name: str | None = None
+    product_code: str | None = None
+    ip_address: str | None = None
+    stored_ip_address: str | None = None
+    reported_ip_address: str | None = None
+    in_soundcork: bool
+    rest_reachable: bool
+    marge_url: str | None = None
+    marge_server: str
+    uses_this_soundcork: bool
+    source: str
+    error: str | None = None
+
+
+class ManagementDevicesResponse(BaseModel):
+    devices: list[ManagementDevice]
+
+
+@dataclass
+class SpeakerInfo:
+    device_id: str
+    name: str | None = None
+    product_code: str | None = None
+    ip_address: str | None = None
+    account_id: str | None = None
+    marge_url: str | None = None
+
+
+def _element_text(element: ET.Element, path: str) -> str | None:
+    child = element.find(path)
+    if child is None or child.text is None:
+        return None
+    text = child.text.strip()
+    if not text:
+        return None
+    return text
+
+
+def _speaker_info_from_xml(info_xml: str) -> SpeakerInfo | None:
+    if not info_xml:
+        return None
+
+    try:
+        root = ET.fromstring(info_xml)
+    except ET.ParseError:
+        return None
+
+    device_id = root.attrib.get("deviceID", "").strip()
+    if not device_id:
+        return None
+
+    product_parts = [
+        part
+        for part in (
+            _element_text(root, "type"),
+            _element_text(root, "moduleType"),
+        )
+        if part
+    ]
+
+    ip_address = None
+    for network_info in root.findall("networkInfo"):
+        if network_info.attrib.get("type") == "SCM":
+            ip_address = _element_text(network_info, "ipAddress")
+            break
+    if ip_address is None:
+        ip_address = _element_text(root, "networkInfo/ipAddress")
+
+    return SpeakerInfo(
+        device_id=device_id,
+        name=_element_text(root, "name"),
+        product_code=" ".join(product_parts) or None,
+        ip_address=ip_address,
+        account_id=_element_text(root, "margeAccountUUID"),
+        marge_url=_element_text(root, "margeURL"),
+    )
+
+
+def _marge_server(marge_url: str | None, base_url: str) -> str:
+    if not marge_url:
+        return "Unknown"
+    if marge_url == BOSE_MARGE_URL:
+        return "Bose"
+    if marge_url.rstrip("/") == f"{base_url.rstrip('/')}/marge":
+        return "Soundcork"
+    return "Other"
+
+
+def _device_from_stored_info(
+    account_id: str,
+    stored: DeviceInfo,
+) -> ManagementDevice:
+    return ManagementDevice(
+        device_id=stored.device_id,
+        account_id=account_id,
+        name=stored.name,
+        product_code=stored.product_code,
+        ip_address=stored.ip_address,
+        stored_ip_address=stored.ip_address,
+        in_soundcork=True,
+        rest_reachable=False,
+        marge_server="Unknown",
+        uses_this_soundcork=False,
+        source="datastore",
+    )
+
+
+def _merge_fresh_info(
+    device: ManagementDevice,
+    speaker_info: SpeakerInfo,
+    base_url: str,
+    source: str | None = None,
+) -> ManagementDevice:
+    if source:
+        device.source = source
+
+    device.rest_reachable = True
+    device.reported_account_id = speaker_info.account_id
+    device.reported_ip_address = speaker_info.ip_address
+    device.marge_url = speaker_info.marge_url
+    device.marge_server = _marge_server(speaker_info.marge_url, base_url)
+    device.uses_this_soundcork = device.marge_server == "Soundcork"
+
+    if speaker_info.name:
+        device.name = speaker_info.name
+    if speaker_info.product_code:
+        device.product_code = speaker_info.product_code
+    if speaker_info.ip_address:
+        device.ip_address = speaker_info.ip_address
+
+    if speaker_info.device_id != device.device_id:
+        device.error = (
+            f"Stored device ID {device.device_id} differs from "
+            f"speaker-reported device ID {speaker_info.device_id}"
+        )
+
+    return device
+
+
+def _fetch_speaker_info(
+    hostname: str,
+    fetch_info: Callable[[str], str],
+) -> tuple[SpeakerInfo | None, str | None]:
+    try:
+        info_xml = fetch_info(hostname)
+    except Exception as e:
+        logger.info("Failed to fetch speaker info from %s: %s", hostname, e)
+        return None, f"Unable to fetch /info from {hostname}"
+
+    if not info_xml:
+        return None, None
+
+    speaker_info = _speaker_info_from_xml(info_xml)
+    if speaker_info is None:
+        return None, f"Unable to parse /info from {hostname}"
+
+    return speaker_info, None
+
+
+def list_management_devices(
+    store: DataStore,
+    config: Settings,
+    account_filter: str | None = None,
+    include_discovered: bool = False,
+    refresh: bool = True,
+    fetch_info: Callable[[str], str] | None = None,
+    discover_devices: Callable[[], Iterable] | None = None,
+) -> ManagementDevicesResponse:
+    """Return a sanitized device inventory for management clients."""
+    if fetch_info is None:
+        fetch_info = read_device_info
+    if discover_devices is None:
+        discover_devices = get_bose_devices
+
+    devices: dict[str, ManagementDevice] = {}
+    base_url = config.base_url
+
+    accounts = [account_filter] if account_filter else store.list_accounts()
+    for account_id in accounts:
+        if not account_id:
+            continue
+        for device_id in store.list_devices(account_id):
+            if not device_id:
+                continue
+            stored = store.get_device_info(account_id, device_id)
+            device = _device_from_stored_info(account_id, stored)
+            devices[device_id] = device
+
+            if refresh and stored.ip_address:
+                fresh, error = _fetch_speaker_info(stored.ip_address, fetch_info)
+                if fresh:
+                    _merge_fresh_info(device, fresh, base_url)
+                elif error:
+                    device.error = error
+
+    if include_discovered:
+        for discovered_device in discover_devices():
+            try:
+                hostname = hostname_for_device(discovered_device)
+            except AttributeError:
+                continue
+            if not hostname:
+                continue
+
+            fresh, _error = _fetch_speaker_info(hostname, fetch_info)
+            if not fresh:
+                continue
+            if account_filter and fresh.account_id != account_filter:
+                continue
+
+            device = devices.get(fresh.device_id)
+            if device:
+                _merge_fresh_info(device, fresh, base_url, source="datastore+discovery")
+                continue
+
+            marge_server = _marge_server(fresh.marge_url, base_url)
+            device = ManagementDevice(
+                device_id=fresh.device_id,
+                account_id=fresh.account_id,
+                in_soundcork=False,
+                rest_reachable=True,
+                marge_server=marge_server,
+                uses_this_soundcork=marge_server == "Soundcork",
+                source="discovery",
+            )
+            _merge_fresh_info(device, fresh, base_url, source="discovery")
+            devices[fresh.device_id] = device
+
+    return ManagementDevicesResponse(devices=sorted(devices.values(), key=_device_key))
+
+
+def _device_key(device: ManagementDevice) -> tuple[str, str]:
+    return (device.account_id or "", device.name or device.device_id)
+
+
+@router.get("/devices", response_model=ManagementDevicesResponse)
+def management_devices(
+    include_discovered: Annotated[
+        bool,
+        Query(description="Also include speakers found through local UPnP discovery."),
+    ] = False,
+    refresh: Annotated[
+        bool,
+        Query(description="Refresh stored speakers through their HTTP /info endpoint."),
+    ] = True,
+):
+    """List SoundTouch speakers without exposing raw Bose account XML."""
+    return list_management_devices(
+        datastore,
+        settings,
+        include_discovered=include_discovered,
+        refresh=refresh,
+    )
+
+
+@router.get("/accounts/{account}/devices", response_model=ManagementDevicesResponse)
+def management_account_devices(
+    account: str,
+    include_discovered: Annotated[
+        bool,
+        Query(description="Also include speakers found through local UPnP discovery."),
+    ] = False,
+    refresh: Annotated[
+        bool,
+        Query(description="Refresh stored speakers through their HTTP /info endpoint."),
+    ] = True,
+):
+    """List SoundTouch speakers for one Soundcork account."""
+    if not datastore.account_exists(account):
+        raise HTTPException(status_code=404, detail=f"Account {account} not found")
+
+    return list_management_devices(
+        datastore,
+        settings,
+        account_filter=account,
+        include_discovered=include_discovered,
+        refresh=refresh,
+    )
 
 
 # --- Spotify ---

--- a/soundcork/tests/test_devices.py
+++ b/soundcork/tests/test_devices.py
@@ -1,0 +1,20 @@
+from soundcork.devices import read_file_from_speaker_http
+
+
+def test_read_file_from_speaker_http_passes_timeout(monkeypatch):
+    calls = []
+
+    class Response:
+        def read(self) -> bytes:
+            return b"<info />"
+
+    def fake_urlopen(url: str, timeout: int):
+        calls.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr("soundcork.devices.urllib.request.urlopen", fake_urlopen)
+
+    result = read_file_from_speaker_http("192.0.2.10", "/info", timeout=7)
+
+    assert result == "<info />"
+    assert calls == [("http://192.0.2.10:8090/info", 7)]

--- a/soundcork/tests/test_management.py
+++ b/soundcork/tests/test_management.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.management import (
+    BOSE_MARGE_URL,
+    _marge_server,
+    list_management_devices,
+    router,
+)
+from soundcork.model import DeviceInfo
+
+ACCOUNT_ID = "8208423"
+DEVICE_ID = "000C8A123456"
+BASE_URL = "http://unifi:8001"
+
+
+def device_info_xml(
+    marge_url: str = f"{BASE_URL}/marge",
+    account_id: str = ACCOUNT_ID,
+    ip_address: str = "192.168.11.71",
+) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<info deviceID="{DEVICE_ID}">
+    <name>kuchyn</name>
+    <type>SoundTouch10</type>
+    <moduleType>SM2</moduleType>
+    <networkInfo type="SCM">
+        <ipAddress>{ip_address}</ipAddress>
+    </networkInfo>
+    <margeURL>{marge_url}</margeURL>
+    <margeAccountUUID>{account_id}</margeAccountUUID>
+</info>"""
+
+
+class FakeDatastore:
+    def __init__(self):
+        self.device = DeviceInfo(
+            device_id=DEVICE_ID,
+            product_code="SoundTouch10 SM2",
+            device_serial_number="8675309",
+            product_serial_number="314519",
+            firmware_version="27.0.0",
+            ip_address="192.168.11.71",
+            name="kuchyn",
+            created_on="2026-06-09T00:00:00.000+00:00",
+            updated_on="2026-06-09T00:00:00.000+00:00",
+        )
+
+    def account_exists(self, account_id: str) -> bool:
+        return account_id == ACCOUNT_ID
+
+    def list_accounts(self) -> list[str]:
+        return [ACCOUNT_ID]
+
+    def list_devices(self, account_id: str) -> list[str]:
+        assert account_id == ACCOUNT_ID
+        return [DEVICE_ID]
+
+    def get_device_info(self, account_id: str, device_id: str) -> DeviceInfo:
+        assert account_id == ACCOUNT_ID
+        assert device_id == DEVICE_ID
+        return self.device
+
+
+def test_marge_server_classifies_known_urls():
+    assert _marge_server(None, BASE_URL) == "Unknown"
+    assert _marge_server(BOSE_MARGE_URL, BASE_URL) == "Bose"
+    assert _marge_server(f"{BASE_URL}/marge", BASE_URL) == "Soundcork"
+    assert _marge_server("http://other.example/marge", BASE_URL) == "Other"
+
+
+def test_list_management_devices_refreshes_marge_url_from_speaker_info():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: device_info_xml(),
+    )
+
+    device = response.devices[0]
+
+    assert device.device_id == DEVICE_ID
+    assert device.account_id == ACCOUNT_ID
+    assert device.reported_account_id == ACCOUNT_ID
+    assert device.rest_reachable is True
+    assert device.marge_url == f"{BASE_URL}/marge"
+    assert device.marge_server == "Soundcork"
+    assert device.uses_this_soundcork is True
+
+
+def test_list_management_devices_keeps_stored_device_when_refresh_fails():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: "",
+    )
+
+    device = response.devices[0]
+
+    assert device.device_id == DEVICE_ID
+    assert device.rest_reachable is False
+    assert device.marge_url is None
+    assert device.marge_server == "Unknown"
+    assert device.uses_this_soundcork is False
+
+
+def test_list_management_devices_reports_unparseable_speaker_info():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: "<info>",
+    )
+
+    device = response.devices[0]
+
+    assert device.rest_reachable is False
+    assert device.error == "Unable to parse /info from 192.168.11.71"
+
+
+def test_management_devices_endpoint_uses_current_speaker_info(monkeypatch):
+    monkeypatch.setattr("soundcork.management.datastore", FakeDatastore())
+    monkeypatch.setattr(
+        "soundcork.management.settings", SimpleNamespace(base_url=BASE_URL)
+    )
+    monkeypatch.setattr(
+        "soundcork.management.read_device_info",
+        lambda _host: device_info_xml(marge_url=BOSE_MARGE_URL),
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    response = TestClient(app).get("/mgmt/devices")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["devices"][0]["marge_server"] == "Bose"
+    assert payload["devices"][0]["uses_this_soundcork"] is False


### PR DESCRIPTION
## Summary

Adds a small JSON management API for listing SoundTouch devices without scraping the admin HTML page.

## Rationale

The existing `/scan` endpoint is useful during setup, but it is local-discovery oriented and does not expose Soundcork's stored device inventory. The admin page also mixes stored state with cached discovery state, which can be stale if a speaker configuration was changed outside Soundcork.

## Implementation

This adds `GET /mgmt/devices` and `GET /mgmt/accounts/{account}/devices`. The response combines datastore device information with an optional fresh speaker `/info` refresh and reports whether the live `margeURL` points to this Soundcork instance, Bose, another server, or is unknown.

The response is intentionally sanitized. It exposes device/account identifiers, IP addresses, reachability, and `margeURL` classification, but it does not expose raw `/marge/full` XML, source secrets, or account source configuration.

Speaker HTTP reads now also pass a bounded timeout to `urllib.request.urlopen()`. Without that, a stored but unreachable speaker can make the management refresh wait indefinitely.

`include_discovered=true` can also include speakers found through local UPnP discovery. By default the endpoint only lists devices already present in the datastore, which avoids making discovery a requirement for routed or non-local speakers.

## Validation

Ran:

```sh
UV_CACHE_DIR=/tmp/uv-cache uv run python -m pytest soundcork/tests/test_management.py soundcork/tests/test_miniapp.py -q
```

Result: `6 passed`.

I also deployed the same code path to a live UniFi-hosted Soundcork instance and verified that `/mgmt/devices?refresh=true` returns `200 application/json`. The unit tests exercise fresh `/info` refresh, Bose/Soundcork/other URL classification, parse failures, timeout propagation, and the FastAPI route.

## Compatibility and scope

This is additive and does not change existing Bose protocol endpoints, admin HTML, miniapp behavior, or `/scan`.
