### PR TITLE
Improve admin device repair state

### DIFF
--- a/soundcork/admin.py
+++ b/soundcork/admin.py
@@ -69,6 +69,10 @@ def _apply_management_state(
     device.state_source = management_device.source
     device.error = management_device.error
     device.in_soundcork = management_device.in_soundcork
+    device.source_statuses = management_device.source_statuses
+    device.internet_radio_ready = management_device.internet_radio_ready
+    device.playback_capability = management_device.playback_capability
+    device.playback_capability_detail = management_device.playback_capability_detail
 
     if management_device.account_id:
         device.account = management_device.account_id

--- a/soundcork/admin.py
+++ b/soundcork/admin.py
@@ -22,11 +22,16 @@ from soundcork.constants import ACCOUNT_RE
 from soundcork.datastore import DataStore
 from soundcork.devices import (
     add_device_by_ip,
-    addr_is_reachable,
+    addr_port_is_reachable,
     default_sources,
     override_speaker_config,
     override_speaker_config_non_rooted,
     reboot_speaker,
+)
+from soundcork.management import (
+    ManagementDevice,
+    list_management_devices,
+    settings as management_settings,
 )
 from soundcork.model import ConfiguredSource
 from soundcork.ui.speakers import CombinedDevice, Speakers
@@ -34,6 +39,83 @@ from soundcork.ui.speakers import CombinedDevice, Speakers
 router = APIRouter(tags=["admin"])
 
 logger = logging.getLogger(__name__)
+
+SSH_PORT = 22
+CLISERVER_PORT = 17000
+
+
+def _management_devices_by_id(datastore: DataStore) -> dict[str, ManagementDevice]:
+    return {
+        device.device_id: device
+        for device in list_management_devices(
+            datastore,
+            management_settings,
+            include_discovered=True,
+            refresh=True,
+        ).devices
+    }
+
+
+def _apply_management_state(
+    device: CombinedDevice,
+    management_device: ManagementDevice | None,
+) -> CombinedDevice:
+    if not management_device:
+        return device
+
+    device.rest_reachable = management_device.rest_reachable
+    device.marge_url = management_device.marge_url
+    device.marge_server = management_device.marge_server
+    device.state_source = management_device.source
+    device.error = management_device.error
+    device.in_soundcork = management_device.in_soundcork
+
+    if management_device.account_id:
+        device.account = management_device.account_id
+    elif management_device.reported_account_id:
+        device.account = management_device.reported_account_id
+
+    if management_device.ip_address:
+        device.ip = management_device.ip_address
+    if management_device.name:
+        device.name = management_device.name
+    if management_device.product_code:
+        logger.debug(
+            "Device %s reports product %s", device.id, management_device.product_code
+        )
+
+    return device
+
+
+def _refresh_device_reachability(device: CombinedDevice) -> CombinedDevice:
+    device.ssh_reachable = addr_port_is_reachable(device.ip, SSH_PORT)
+    device.telnet_reachable = addr_port_is_reachable(device.ip, CLISERVER_PORT)
+    device.reachable = device.ssh_reachable
+    device.repair_available = device.marge_server != "Soundcork" and (
+        device.ssh_reachable or device.telnet_reachable
+    )
+    return device
+
+
+def _host_for_repair(
+    combined_device: CombinedDevice | None,
+    management_device: ManagementDevice | None,
+) -> str | None:
+    if management_device:
+        if management_device.ip_address:
+            return management_device.ip_address
+        if management_device.stored_ip_address:
+            return management_device.stored_ip_address
+        if management_device.reported_ip_address:
+            return management_device.reported_ip_address
+
+    if combined_device:
+        if combined_device.ip:
+            return combined_device.ip
+        if combined_device.st_device:
+            return combined_device.st_device.Host
+
+    return None
 
 
 def get_admin_router(datastore: DataStore, speakers: Speakers):
@@ -52,6 +134,7 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
     @router.get("/admin/", response_class=HTMLResponse)
     async def admin(request: Request):
         combined_devices = speakers.all_devices()
+        management_devices = _management_devices_by_id(datastore)
 
         unassociated_devices = []
         account_ids = datastore.list_accounts()
@@ -68,6 +151,9 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
         sorted_keys = sorted(combined_devices)
         for key in sorted_keys:
             dev = combined_devices[key]
+            _apply_management_state(dev, management_devices.get(dev.id))
+            _refresh_device_reachability(dev)
+
             # assign to account
             account_id = dev.account
             if account_id:
@@ -90,9 +176,6 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
                 except:
                     dev.language_code = "0"
 
-            # also check to see if it's available via ssh
-            dev.reachable = addr_is_reachable(dev.ip)
-
         return templates.TemplateResponse(
             request=request,
             name="admin/admin_main.html",
@@ -112,22 +195,36 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
     @router.post("/admin/switchToSoundcork/{device_id}")
     async def switch_device(device_id: str):
         logger.info(f"switch {device_id} to soundcork")
+        management_devices = _management_devices_by_id(datastore)
+        management_device = management_devices.get(device_id)
         combined_device = speakers.all_devices().get(device_id)
-        if combined_device:
-            st_device = combined_device.st_device
-            if st_device:
-                hostname = st_device.Host
-                if combined_device.reachable:
-                    success = override_speaker_config(hostname)
-                    reboot = reboot_speaker(hostname)
-                    logger.info(f"reboot {hostname} result {reboot}")
+        hostname = _host_for_repair(combined_device, management_device)
+
+        if hostname:
+            ssh_reachable = addr_port_is_reachable(hostname, SSH_PORT)
+            telnet_reachable = addr_port_is_reachable(hostname, CLISERVER_PORT)
+
+            if ssh_reachable:
+                success = override_speaker_config(hostname)
+                reboot = reboot_speaker(hostname)
+                logger.info(f"reboot {hostname} result {reboot}")
+                if success:
                     speakers.clear_device(device_id)
-                else:
-                    success = await override_speaker_config_non_rooted(hostname)
-                    logger.info(
-                        f"override speaker config on {hostname} success = {success}"
-                    )
+            elif telnet_reachable:
+                success = await override_speaker_config_non_rooted(hostname)
+                logger.info(
+                    f"override speaker config on {hostname} success = {success}"
+                )
+                if success:
                     speakers.clear_device(device_id)
+            else:
+                logger.warning(
+                    "cannot switch %s to Soundcork: no SSH or CLIServer access",
+                    device_id,
+                )
+        else:
+            logger.warning("cannot switch %s to Soundcork: no host known", device_id)
+
         # wait a little for the speaker to restart
         time.sleep(10)
         return RedirectResponse(

--- a/soundcork/admin.py
+++ b/soundcork/admin.py
@@ -50,7 +50,7 @@ def _management_devices_by_id(datastore: DataStore) -> dict[str, ManagementDevic
         for device in list_management_devices(
             datastore,
             management_settings,
-            include_discovered=True,
+            include_discovered=False,
             refresh=True,
         ).devices
     }
@@ -88,8 +88,10 @@ def _apply_management_state(
 
 
 def _refresh_device_reachability(device: CombinedDevice) -> CombinedDevice:
-    device.ssh_reachable = addr_port_is_reachable(device.ip, SSH_PORT)
-    device.telnet_reachable = addr_port_is_reachable(device.ip, CLISERVER_PORT)
+    device.ssh_reachable = addr_port_is_reachable(device.ip, SSH_PORT, timeout=0.5)
+    device.telnet_reachable = addr_port_is_reachable(
+        device.ip, CLISERVER_PORT, timeout=0.5
+    )
     device.reachable = device.ssh_reachable
     device.repair_available = device.marge_server != "Soundcork" and (
         device.ssh_reachable or device.telnet_reachable

--- a/soundcork/admin.py
+++ b/soundcork/admin.py
@@ -4,7 +4,6 @@ Endpoints for an admin UI.
 """
 
 import logging
-import time
 from http import HTTPStatus
 from typing import Annotated
 
@@ -231,8 +230,6 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
         else:
             logger.warning("cannot switch %s to Soundcork: no host known", device_id)
 
-        # wait a little for the speaker to restart
-        time.sleep(10)
         return RedirectResponse(
             url=f"/admin/wait/{device_id}/0", status_code=HTTPStatus.FOUND
         )
@@ -243,11 +240,6 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
         # only wait up to 120 seconds
         if elapsed >= 120:
             return RedirectResponse(url=f"/admin/", status_code=HTTPStatus.FOUND)
-
-        if elapsed == 0:
-            # for the first request wait 40 seconds
-            time.sleep(40)
-            elapsed = 40
 
         combined_device = speakers.all_devices().get(device_id)
         if combined_device:

--- a/soundcork/constants.py
+++ b/soundcork/constants.py
@@ -67,6 +67,7 @@ SPEAKER_HTTP_PORT = 8090
 SPEAKER_DEVICE_INFO_PATH = "/info"
 SPEAKER_RECENTS_PATH = "/recents"
 SPEAKER_PRESETS_PATH = "/presets"
+SPEAKER_SOURCES_PATH = "/sources"
 # this one needs to be pulled from a device
 SPEAKER_SOURCES_FILE_LOCATION = "/mnt/nv/BoseApp-Persistence/1/Sources.xml"
 SPEAKER_OVERRIDE_SDK_LOCATION = "/mnt/nv/OverrideSdkPrivateCfg.xml"

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -229,7 +229,7 @@ def is_reachable(device: upnpclient.upnp.Device) -> bool:
     return bool(device_address and addr_is_reachable(device_address))
 
 
-def addr_port_is_reachable(device_address: str, port: int, timeout: int = 2) -> bool:
+def addr_port_is_reachable(device_address: str, port: int, timeout: float = 2) -> bool:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.settimeout(timeout)
     try:

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -172,12 +172,12 @@ def read_file_from_speaker_ssh(host: str, remote_path: str, local_path: str) -> 
         logger.info(f"Error: {e}")
 
 
-def read_file_from_speaker_http(host: str, path: str) -> str:
+def read_file_from_speaker_http(host: str, path: str, timeout: int = 2) -> str:
     """Read a file from the remote speaker, using their HTTP API."""
     url = f"http://{host}:{SPEAKER_HTTP_PORT}{path}"
     logger.info(f"checking {url}")
     try:
-        return str(urllib.request.urlopen(url).read(), "utf-8")
+        return str(urllib.request.urlopen(url, timeout=timeout).read(), "utf-8")
     except Exception:
         logger.info(f"no result for {url}")
         return ""

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -31,6 +31,7 @@ from soundcork.constants import (
     SPEAKER_PRESETS_PATH,
     SPEAKER_RECENTS_PATH,
     SPEAKER_SOURCES_FILE_LOCATION,
+    SPEAKER_SOURCES_PATH,
 )
 from soundcork.datastore import DataStore
 from soundcork.model import ConfiguredSource
@@ -65,6 +66,10 @@ def read_device_info(hostname: str) -> str:
 
 def read_presets(hostname: str) -> str:
     return read_file_from_speaker_http(hostname, SPEAKER_PRESETS_PATH)
+
+
+def read_runtime_sources(hostname: str) -> str:
+    return read_file_from_speaker_http(hostname, SPEAKER_SOURCES_PATH)
 
 
 def read_sources(hostname: str) -> str:

--- a/soundcork/devices.py
+++ b/soundcork/devices.py
@@ -226,17 +226,23 @@ def show_upnp_devices() -> None:
 def is_reachable(device: upnpclient.upnp.Device) -> bool:
     """Returns true if device is reachable via telnet, ssh, etc."""
     device_address = urlparse(device.location).hostname
-    return is_reachable(device_address)
+    return bool(device_address and addr_is_reachable(device_address))
 
 
-def addr_is_reachable(device_address: str) -> bool:
+def addr_port_is_reachable(device_address: str, port: int, timeout: int = 2) -> bool:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.settimeout(2)  # Timeout in case of port not open
+    s.settimeout(timeout)
     try:
-        s.connect((device_address, 22))  # Port ,Here 22 is port
+        s.connect((device_address, port))
         return True
     except:
         return False
+    finally:
+        s.close()
+
+
+def addr_is_reachable(device_address: str) -> bool:
+    return addr_port_is_reachable(device_address, 22)
 
 
 def add_device(device: upnpclient.upnp.Device) -> bool:

--- a/soundcork/management.py
+++ b/soundcork/management.py
@@ -22,11 +22,16 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
-from soundcork.devices import get_bose_devices, hostname_for_device, read_device_info
+from soundcork.devices import (
+    get_bose_devices,
+    hostname_for_device,
+    read_device_info,
+    read_runtime_sources,
+)
 from soundcork.model import DeviceInfo
 from soundcork.spotify_service import SpotifyService
 
@@ -39,6 +44,7 @@ settings = Settings()
 spotify = SpotifyService()
 
 BOSE_MARGE_URL = "https://streaming.bose.com"
+RADIO_SOURCE_KEYS = ("LOCAL_INTERNET_RADIO", "TUNEIN")
 
 
 class ManagementDevice(BaseModel):
@@ -57,6 +63,10 @@ class ManagementDevice(BaseModel):
     marge_url: str | None = None
     marge_server: str
     uses_this_soundcork: bool
+    source_statuses: dict[str, str] = Field(default_factory=dict)
+    internet_radio_ready: bool | None = None
+    playback_capability: str = "Unknown"
+    playback_capability_detail: str | None = None
     source: str
     error: str | None = None
 
@@ -135,6 +145,82 @@ def _marge_server(marge_url: str | None, base_url: str) -> str:
     return "Other"
 
 
+def _source_statuses_from_xml(sources_xml: str) -> tuple[dict[str, str], str | None]:
+    if not sources_xml:
+        return {}, "Unable to fetch /sources"
+
+    try:
+        root = ET.fromstring(sources_xml)
+    except ET.ParseError:
+        return {}, "Unable to parse /sources"
+
+    statuses: dict[str, str] = {}
+    for source_item in root.findall("sourceItem"):
+        source = source_item.attrib.get("source", "").strip()
+        status = source_item.attrib.get("status", "").strip()
+        if not source:
+            continue
+        if statuses.get(source) == "READY":
+            continue
+        statuses[source] = status or "UNKNOWN"
+
+    return statuses, None
+
+
+def _radio_sources_ready(source_statuses: dict[str, str]) -> bool:
+    return any(source_statuses.get(source) == "READY" for source in RADIO_SOURCE_KEYS)
+
+
+def _radio_source_summary(source_statuses: dict[str, str]) -> str:
+    parts = [
+        f"{source}={source_statuses.get(source, 'missing')}"
+        for source in RADIO_SOURCE_KEYS
+    ]
+    return ", ".join(parts)
+
+
+def _playback_capability(
+    marge_server: str,
+    rest_reachable: bool,
+    source_statuses: dict[str, str],
+    sources_error: str | None = None,
+) -> tuple[str, str]:
+    if not rest_reachable:
+        return "Unknown", "REST /info is not reachable."
+    if sources_error:
+        return "Unknown", sources_error
+
+    radio_ready = _radio_sources_ready(source_statuses)
+    source_summary = _radio_source_summary(source_statuses)
+
+    if marge_server == "Soundcork":
+        if radio_ready:
+            return "Soundcork-ready", f"Radio sources are ready: {source_summary}."
+        return (
+            "Needs repair",
+            "Speaker points at this Soundcork, but radio sources are not ready: "
+            f"{source_summary}.",
+        )
+
+    if marge_server == "Bose":
+        if radio_ready:
+            return (
+                "Legacy-ready",
+                "Speaker still points at Bose, but radio sources are currently "
+                f"ready: {source_summary}. This may only last until reboot.",
+            )
+        return (
+            "Needs repair",
+            "Speaker points at Bose and radio sources are not ready: "
+            f"{source_summary}.",
+        )
+
+    if radio_ready:
+        return "Legacy-ready", f"Radio sources are ready: {source_summary}."
+
+    return "Unknown", f"Radio source state is inconclusive: {source_summary}."
+
+
 def _device_from_stored_info(
     account_id: str,
     stored: DeviceInfo,
@@ -150,6 +236,8 @@ def _device_from_stored_info(
         rest_reachable=False,
         marge_server="Unknown",
         uses_this_soundcork=False,
+        playback_capability="Unknown",
+        playback_capability_detail="REST /info is not reachable.",
         source="datastore",
     )
 
@@ -186,6 +274,35 @@ def _merge_fresh_info(
     return device
 
 
+def _merge_fresh_sources(
+    device: ManagementDevice,
+    hostname: str,
+    fetch_sources: Callable[[str], str],
+) -> ManagementDevice:
+    try:
+        sources_xml = fetch_sources(hostname)
+    except Exception as e:
+        logger.info("Failed to fetch speaker sources from %s: %s", hostname, e)
+        sources_xml = ""
+
+    source_statuses, sources_error = _source_statuses_from_xml(sources_xml)
+    if sources_error:
+        sources_error = f"{sources_error} from {hostname}"
+
+    device.source_statuses = source_statuses
+    device.internet_radio_ready = _radio_sources_ready(source_statuses)
+    (
+        device.playback_capability,
+        device.playback_capability_detail,
+    ) = _playback_capability(
+        device.marge_server,
+        device.rest_reachable,
+        source_statuses,
+        sources_error,
+    )
+    return device
+
+
 def _fetch_speaker_info(
     hostname: str,
     fetch_info: Callable[[str], str],
@@ -213,11 +330,14 @@ def list_management_devices(
     include_discovered: bool = False,
     refresh: bool = True,
     fetch_info: Callable[[str], str] | None = None,
+    fetch_sources: Callable[[str], str] | None = None,
     discover_devices: Callable[[], Iterable] | None = None,
 ) -> ManagementDevicesResponse:
     """Return a sanitized device inventory for management clients."""
     if fetch_info is None:
         fetch_info = read_device_info
+    if fetch_sources is None:
+        fetch_sources = read_runtime_sources
     if discover_devices is None:
         discover_devices = get_bose_devices
 
@@ -239,6 +359,9 @@ def list_management_devices(
                 fresh, error = _fetch_speaker_info(stored.ip_address, fetch_info)
                 if fresh:
                     _merge_fresh_info(device, fresh, base_url)
+                    _merge_fresh_sources(
+                        device, fresh.ip_address or stored.ip_address, fetch_sources
+                    )
                 elif error:
                     device.error = error
 
@@ -260,6 +383,7 @@ def list_management_devices(
             device = devices.get(fresh.device_id)
             if device:
                 _merge_fresh_info(device, fresh, base_url, source="datastore+discovery")
+                _merge_fresh_sources(device, hostname, fetch_sources)
                 continue
 
             marge_server = _marge_server(fresh.marge_url, base_url)
@@ -273,6 +397,7 @@ def list_management_devices(
                 source="discovery",
             )
             _merge_fresh_info(device, fresh, base_url, source="discovery")
+            _merge_fresh_sources(device, hostname, fetch_sources)
             devices[fresh.device_id] = device
 
     return ManagementDevicesResponse(devices=sorted(devices.values(), key=_device_key))

--- a/soundcork/management.py
+++ b/soundcork/management.py
@@ -15,13 +15,19 @@ SPOTIFY_CLIENT_SECRET are configured.
 #        be modified from the admin UI
 
 import logging
+import xml.etree.ElementTree as ET
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from pydantic import BaseModel
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
+from soundcork.devices import get_bose_devices, hostname_for_device, read_device_info
+from soundcork.model import DeviceInfo
 from soundcork.spotify_service import SpotifyService
 
 logger = logging.getLogger(__name__)
@@ -31,6 +37,294 @@ router = APIRouter(prefix="/mgmt", tags=["management"])
 datastore = DataStore()
 settings = Settings()
 spotify = SpotifyService()
+
+BOSE_MARGE_URL = "https://streaming.bose.com"
+
+
+class ManagementDevice(BaseModel):
+    """Sanitized management view of a SoundTouch speaker."""
+
+    device_id: str
+    account_id: str | None = None
+    reported_account_id: str | None = None
+    name: str | None = None
+    product_code: str | None = None
+    ip_address: str | None = None
+    stored_ip_address: str | None = None
+    reported_ip_address: str | None = None
+    in_soundcork: bool
+    rest_reachable: bool
+    marge_url: str | None = None
+    marge_server: str
+    uses_this_soundcork: bool
+    source: str
+    error: str | None = None
+
+
+class ManagementDevicesResponse(BaseModel):
+    devices: list[ManagementDevice]
+
+
+@dataclass
+class SpeakerInfo:
+    device_id: str
+    name: str | None = None
+    product_code: str | None = None
+    ip_address: str | None = None
+    account_id: str | None = None
+    marge_url: str | None = None
+
+
+def _element_text(element: ET.Element, path: str) -> str | None:
+    child = element.find(path)
+    if child is None or child.text is None:
+        return None
+    text = child.text.strip()
+    if not text:
+        return None
+    return text
+
+
+def _speaker_info_from_xml(info_xml: str) -> SpeakerInfo | None:
+    if not info_xml:
+        return None
+
+    try:
+        root = ET.fromstring(info_xml)
+    except ET.ParseError:
+        return None
+
+    device_id = root.attrib.get("deviceID", "").strip()
+    if not device_id:
+        return None
+
+    product_parts = [
+        part
+        for part in (
+            _element_text(root, "type"),
+            _element_text(root, "moduleType"),
+        )
+        if part
+    ]
+
+    ip_address = None
+    for network_info in root.findall("networkInfo"):
+        if network_info.attrib.get("type") == "SCM":
+            ip_address = _element_text(network_info, "ipAddress")
+            break
+    if ip_address is None:
+        ip_address = _element_text(root, "networkInfo/ipAddress")
+
+    return SpeakerInfo(
+        device_id=device_id,
+        name=_element_text(root, "name"),
+        product_code=" ".join(product_parts) or None,
+        ip_address=ip_address,
+        account_id=_element_text(root, "margeAccountUUID"),
+        marge_url=_element_text(root, "margeURL"),
+    )
+
+
+def _marge_server(marge_url: str | None, base_url: str) -> str:
+    if not marge_url:
+        return "Unknown"
+    if marge_url == BOSE_MARGE_URL:
+        return "Bose"
+    if marge_url.rstrip("/") == f"{base_url.rstrip('/')}/marge":
+        return "Soundcork"
+    return "Other"
+
+
+def _device_from_stored_info(
+    account_id: str,
+    stored: DeviceInfo,
+) -> ManagementDevice:
+    return ManagementDevice(
+        device_id=stored.device_id,
+        account_id=account_id,
+        name=stored.name,
+        product_code=stored.product_code,
+        ip_address=stored.ip_address,
+        stored_ip_address=stored.ip_address,
+        in_soundcork=True,
+        rest_reachable=False,
+        marge_server="Unknown",
+        uses_this_soundcork=False,
+        source="datastore",
+    )
+
+
+def _merge_fresh_info(
+    device: ManagementDevice,
+    speaker_info: SpeakerInfo,
+    base_url: str,
+    source: str | None = None,
+) -> ManagementDevice:
+    if source:
+        device.source = source
+
+    device.rest_reachable = True
+    device.reported_account_id = speaker_info.account_id
+    device.reported_ip_address = speaker_info.ip_address
+    device.marge_url = speaker_info.marge_url
+    device.marge_server = _marge_server(speaker_info.marge_url, base_url)
+    device.uses_this_soundcork = device.marge_server == "Soundcork"
+
+    if speaker_info.name:
+        device.name = speaker_info.name
+    if speaker_info.product_code:
+        device.product_code = speaker_info.product_code
+    if speaker_info.ip_address:
+        device.ip_address = speaker_info.ip_address
+
+    if speaker_info.device_id != device.device_id:
+        device.error = (
+            f"Stored device ID {device.device_id} differs from "
+            f"speaker-reported device ID {speaker_info.device_id}"
+        )
+
+    return device
+
+
+def _fetch_speaker_info(
+    hostname: str,
+    fetch_info: Callable[[str], str],
+) -> tuple[SpeakerInfo | None, str | None]:
+    try:
+        info_xml = fetch_info(hostname)
+    except Exception as e:
+        logger.info("Failed to fetch speaker info from %s: %s", hostname, e)
+        return None, f"Unable to fetch /info from {hostname}"
+
+    if not info_xml:
+        return None, None
+
+    speaker_info = _speaker_info_from_xml(info_xml)
+    if speaker_info is None:
+        return None, f"Unable to parse /info from {hostname}"
+
+    return speaker_info, None
+
+
+def list_management_devices(
+    store: DataStore,
+    config: Settings,
+    account_filter: str | None = None,
+    include_discovered: bool = False,
+    refresh: bool = True,
+    fetch_info: Callable[[str], str] | None = None,
+    discover_devices: Callable[[], Iterable] | None = None,
+) -> ManagementDevicesResponse:
+    """Return a sanitized device inventory for management clients."""
+    if fetch_info is None:
+        fetch_info = read_device_info
+    if discover_devices is None:
+        discover_devices = get_bose_devices
+
+    devices: dict[str, ManagementDevice] = {}
+    base_url = config.base_url
+
+    accounts = [account_filter] if account_filter else store.list_accounts()
+    for account_id in accounts:
+        if not account_id:
+            continue
+        for device_id in store.list_devices(account_id):
+            if not device_id:
+                continue
+            stored = store.get_device_info(account_id, device_id)
+            device = _device_from_stored_info(account_id, stored)
+            devices[device_id] = device
+
+            if refresh and stored.ip_address:
+                fresh, error = _fetch_speaker_info(stored.ip_address, fetch_info)
+                if fresh:
+                    _merge_fresh_info(device, fresh, base_url)
+                elif error:
+                    device.error = error
+
+    if include_discovered:
+        for discovered_device in discover_devices():
+            try:
+                hostname = hostname_for_device(discovered_device)
+            except AttributeError:
+                continue
+            if not hostname:
+                continue
+
+            fresh, _error = _fetch_speaker_info(hostname, fetch_info)
+            if not fresh:
+                continue
+            if account_filter and fresh.account_id != account_filter:
+                continue
+
+            device = devices.get(fresh.device_id)
+            if device:
+                _merge_fresh_info(device, fresh, base_url, source="datastore+discovery")
+                continue
+
+            marge_server = _marge_server(fresh.marge_url, base_url)
+            device = ManagementDevice(
+                device_id=fresh.device_id,
+                account_id=fresh.account_id,
+                in_soundcork=False,
+                rest_reachable=True,
+                marge_server=marge_server,
+                uses_this_soundcork=marge_server == "Soundcork",
+                source="discovery",
+            )
+            _merge_fresh_info(device, fresh, base_url, source="discovery")
+            devices[fresh.device_id] = device
+
+    return ManagementDevicesResponse(devices=sorted(devices.values(), key=_device_key))
+
+
+def _device_key(device: ManagementDevice) -> tuple[str, str]:
+    return (device.account_id or "", device.name or device.device_id)
+
+
+@router.get("/devices", response_model=ManagementDevicesResponse)
+def management_devices(
+    include_discovered: Annotated[
+        bool,
+        Query(description="Also include speakers found through local UPnP discovery."),
+    ] = False,
+    refresh: Annotated[
+        bool,
+        Query(description="Refresh stored speakers through their HTTP /info endpoint."),
+    ] = True,
+):
+    """List SoundTouch speakers without exposing raw Bose account XML."""
+    return list_management_devices(
+        datastore,
+        settings,
+        include_discovered=include_discovered,
+        refresh=refresh,
+    )
+
+
+@router.get("/accounts/{account}/devices", response_model=ManagementDevicesResponse)
+def management_account_devices(
+    account: str,
+    include_discovered: Annotated[
+        bool,
+        Query(description="Also include speakers found through local UPnP discovery."),
+    ] = False,
+    refresh: Annotated[
+        bool,
+        Query(description="Refresh stored speakers through their HTTP /info endpoint."),
+    ] = True,
+):
+    """List SoundTouch speakers for one Soundcork account."""
+    if not datastore.account_exists(account):
+        raise HTTPException(status_code=404, detail=f"Account {account} not found")
+
+    return list_management_devices(
+        datastore,
+        settings,
+        account_filter=account,
+        include_discovered=include_discovered,
+        refresh=refresh,
+    )
 
 
 # --- Spotify ---

--- a/soundcork/templates/admin/admin_main.html
+++ b/soundcork/templates/admin/admin_main.html
@@ -6,10 +6,11 @@
             <summary>Status guide</summary>
             <ul>
                 <li><strong>Live Marge</strong> is read from the speaker's current <code>/info</code> response. <strong>Soundcork</strong> means the speaker already points at this server, <strong>Bose</strong> means it still points at Bose cloud URLs, and <strong>Other</strong> means it points somewhere else.</li>
+                <li><strong>Playback</strong> is inferred from the live <code>/sources</code> response. <strong>Soundcork-ready</strong> means this server is selected and radio sources are ready, <strong>Legacy-ready</strong> means the speaker still points at Bose but radio sources are still ready until a reboot, and <strong>Needs repair</strong> means internet radio sources are not currently ready.</li>
                 <li><strong>REST /info</strong> means the speaker answered its HTTP API on port 8090. This is enough to inspect live state, but not enough to rewrite Bose URLs.</li>
                 <li><strong>SSH</strong> means root shell access is available on port 22. Soundcork can copy the override XML and reboot the speaker.</li>
                 <li><strong>Telnet CLIServer</strong> means the non-rooted SoundTouch command port 17000 is reachable. Soundcork can ask the speaker to update its Bose URLs and reboot.</li>
-                <li><strong>Repair Soundcork routing</strong> sets the Bose service URLs to this Soundcork instance. Use it when Live Marge is not Soundcork and either SSH or Telnet CLIServer is available.</li>
+                <li><strong>Switch to Soundcork</strong> sets the Bose service URLs to this Soundcork instance. Use it when Live Marge is not Soundcork and either SSH or Telnet CLIServer is available.</li>
             </ul>
         </details>
 
@@ -25,6 +26,7 @@
                 <th>IP Address</th>
                 <th>Name</th>
                 <th>Live Marge</th>
+                <th>Playback</th>
                 <th>REST /info</th>
                 <th>Discovery</th>
                 <th>In Soundcork</th>
@@ -39,6 +41,7 @@
                     <td>{{device.ip}}</td>
                     <td>{{device.name}}</td>
                     <td title="{{device.marge_url or ''}}">{{device.marge_server}}</td>
+                    <td title="{{device.playback_capability_detail or ''}}">{{device.playback_capability}}</td>
                     <td>{{device.rest_reachable}}</td>
                     <td>{{device.online}}</td>
                     <td>{{device.in_soundcork}}</td>
@@ -57,7 +60,7 @@
                           {% endif %}
                         {% elif device.repair_available %}
                         <form action="/admin/switchToSoundcork/{{device.id}}" method="POST">
-                            <input type="submit" value="Repair Soundcork routing">
+                            <input type="submit" value="Switch to Soundcork">
                         </form>
                         {% elif device.marge_server == "Soundcork" %}
                         Already using Soundcork
@@ -90,6 +93,7 @@
                 <th>IP Address</th>
                 <th>Name</th>
                 <th>Live Marge</th>
+                <th>Playback</th>
                 <th>REST /info</th>
                 <th>Discovery</th>
                 <th>SSH</th>
@@ -103,6 +107,7 @@
                     <td>{{device.ip}}</td>
                     <td>{{device.name}}</td>
                     <td title="{{device.marge_url or ''}}">{{device.marge_server}}</td>
+                    <td title="{{device.playback_capability_detail or ''}}">{{device.playback_capability}}</td>
                     <td>{{device.rest_reachable}}</td>
                     <td>{{device.online}}</td>
                     <td>{{device.ssh_reachable}}</td>
@@ -119,7 +124,7 @@
                         </form>
                         {% elif device.repair_available %}
                         <form action="/admin/switchToSoundcork/{{device.id}}" method="POST">
-                            <input type="submit" value="Repair Soundcork routing">
+                            <input type="submit" value="Switch to Soundcork">
                         </form>
                         {% elif device.marge_server != "Soundcork" %}
                         Needs SSH or Telnet CLIServer

--- a/soundcork/templates/admin/admin_main.html
+++ b/soundcork/templates/admin/admin_main.html
@@ -2,6 +2,17 @@
 {% block title %}Soundcork Admin{% endblock %}
 {% block header %}Soundcork:  Can't Brick Us{% endblock %}
 {% block main %}
+        <details open>
+            <summary>Status guide</summary>
+            <ul>
+                <li><strong>Live Marge</strong> is read from the speaker's current <code>/info</code> response. <strong>Soundcork</strong> means the speaker already points at this server, <strong>Bose</strong> means it still points at Bose cloud URLs, and <strong>Other</strong> means it points somewhere else.</li>
+                <li><strong>REST /info</strong> means the speaker answered its HTTP API on port 8090. This is enough to inspect live state, but not enough to rewrite Bose URLs.</li>
+                <li><strong>SSH</strong> means root shell access is available on port 22. Soundcork can copy the override XML and reboot the speaker.</li>
+                <li><strong>Telnet CLIServer</strong> means the non-rooted SoundTouch command port 17000 is reachable. Soundcork can ask the speaker to update its Bose URLs and reboot.</li>
+                <li><strong>Repair Soundcork routing</strong> sets the Bose service URLs to this Soundcork instance. Use it when Live Marge is not Soundcork and either SSH or Telnet CLIServer is available.</li>
+            </ul>
+        </details>
+
         {% for id, account in accounts.items() %}
         <h2>Account {{account.id}}
             {% if not account.in_soundcork %}
@@ -13,10 +24,12 @@
                 <th>Device</th>
                 <th>IP Address</th>
                 <th>Name</th>
-                <th>Marge</th>
-                <th>Online</th>
+                <th>Live Marge</th>
+                <th>REST /info</th>
+                <th>Discovery</th>
                 <th>In Soundcork</th>
-                <th>Reachable</th>
+                <th>SSH</th>
+                <th>Telnet CLIServer</th>
                 <th>Action</th>
             </thead>
             <tbody></tbody>
@@ -25,13 +38,15 @@
                     <td><a href = "/admin/edit_device/{{device.id}}">{{device.id}}</a></td>
                     <td>{{device.ip}}</td>
                     <td>{{device.name}}</td>
-                    <td>{{device.marge_server}}</td>
+                    <td title="{{device.marge_url or ''}}">{{device.marge_server}}</td>
+                    <td>{{device.rest_reachable}}</td>
                     <td>{{device.online}}</td>
                     <td>{{device.in_soundcork}}</td>
-                    <td>{{device.reachable}}</td>
+                    <td>{{device.ssh_reachable}}</td>
+                    <td>{{device.telnet_reachable}}</td>
                     <td>
                         {% if not device.in_soundcork %}
-                          {% if not account.in_soundcork and device.reachable %}
+                          {% if not account.in_soundcork and device.rest_reachable %}
                             <form action="/admin/addDevice/{{device.id}}" method="POST">
                               <input type="submit" value="Configure Account">
                             </form>
@@ -40,10 +55,16 @@
                               <input type="submit" value="Add to Soundcork">
                             </form>
                           {% endif %}
-                        {% elif device.reachable and device.marge_server != "Soundcork"%}
+                        {% elif device.repair_available %}
                         <form action="/admin/switchToSoundcork/{{device.id}}" method="POST">
-                            <input type="submit" value="Switch to Soundcork">
+                            <input type="submit" value="Repair Soundcork routing">
                         </form>
+                        {% elif device.marge_server == "Soundcork" %}
+                        Already using Soundcork
+                        {% elif device.error %}
+                        {{device.error}}
+                        {% else %}
+                        Needs SSH or Telnet CLIServer
                         {% endif %}
                     </td>
             {% endfor %}
@@ -68,9 +89,11 @@
                 <th>Device</th>
                 <th>IP Address</th>
                 <th>Name</th>
-                <th>Marge</th>
-                <th>Online</th>
-                <th>Reachable</th>
+                <th>Live Marge</th>
+                <th>REST /info</th>
+                <th>Discovery</th>
+                <th>SSH</th>
+                <th>Telnet CLIServer</th>
                 <th>Action</th>
             </thead>
             <tbody></tbody>
@@ -79,9 +102,11 @@
                     <td>{{device.id}}</td>
                     <td>{{device.ip}}</td>
                     <td>{{device.name}}</td>
-                    <td>{{device.marge_server}}</td>
+                    <td title="{{device.marge_url or ''}}">{{device.marge_server}}</td>
+                    <td>{{device.rest_reachable}}</td>
                     <td>{{device.online}}</td>
-                    <td>{{device.reachable}}</td>
+                    <td>{{device.ssh_reachable}}</td>
+                    <td>{{device.telnet_reachable}}</td>
                     <td>
                         {% if device.language_code == "0" %}
                         <form class="inline-form" action = "/admin/{{device.id}}/setLanguage" method="POST">
@@ -92,10 +117,12 @@
                             </select>
                             <input type="submit" value="Set Language">
                         </form>
-                        {% elif device.marge_server != "Soundcork" %}
-                        <form action="/admin/switchToSoundcork/B0D5CC0391DB" method="POST">
-                            <input type="submit" value="Swtich To Soundcork">
+                        {% elif device.repair_available %}
+                        <form action="/admin/switchToSoundcork/{{device.id}}" method="POST">
+                            <input type="submit" value="Repair Soundcork routing">
                         </form>
+                        {% elif device.marge_server != "Soundcork" %}
+                        Needs SSH or Telnet CLIServer
                         {% else %}
                         <form class="inline-form" action="/admin/{{device.id}}/setAccount" method="POST">
                             <select name="account_id">

--- a/soundcork/tests/test_admin.py
+++ b/soundcork/tests/test_admin.py
@@ -1,0 +1,131 @@
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.admin import get_admin_router
+from soundcork.management import ManagementDevice, ManagementDevicesResponse
+from soundcork.ui.speakers import CombinedDevice
+
+ACCOUNT_ID = "8208423"
+DEVICE_ID = "000C8A123456"
+DEVICE_IP = "192.168.11.71"
+
+
+class FakeDatastore:
+    def list_accounts(self) -> list[str]:
+        return [ACCOUNT_ID]
+
+
+class FakeSpeakers:
+    def __init__(self):
+        self.cleared_devices: list[str] = []
+
+    def all_devices(self) -> dict[str, CombinedDevice]:
+        return {
+            DEVICE_ID: CombinedDevice(
+                id=DEVICE_ID,
+                ip=DEVICE_IP,
+                name="Kitchen",
+                online=True,
+                account=ACCOUNT_ID,
+                in_soundcork=True,
+                marge_server="Unknown",
+                reachable=False,
+                st_device=None,
+            )
+        }
+
+    def clear_device(self, device_id: str):
+        self.cleared_devices.append(device_id)
+
+
+def management_devices_response(
+    marge_server: str = "Bose",
+) -> ManagementDevicesResponse:
+    return ManagementDevicesResponse(
+        devices=[
+            ManagementDevice(
+                device_id=DEVICE_ID,
+                account_id=ACCOUNT_ID,
+                reported_account_id=ACCOUNT_ID,
+                name="Kitchen",
+                product_code="SoundTouch10 SM2",
+                ip_address=DEVICE_IP,
+                stored_ip_address=DEVICE_IP,
+                reported_ip_address=DEVICE_IP,
+                in_soundcork=True,
+                rest_reachable=True,
+                marge_url="https://streaming.bose.com",
+                marge_server=marge_server,
+                uses_this_soundcork=False,
+                source="datastore",
+            )
+        ]
+    )
+
+
+def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
+    monkeypatch.chdir(Path(__file__).resolve().parents[1])
+    app = FastAPI()
+    fake_speakers = speakers or FakeSpeakers()
+    app.include_router(get_admin_router(FakeDatastore(), fake_speakers))
+    return TestClient(app), fake_speakers
+
+
+def test_admin_shows_live_marge_and_telnet_repair_action(monkeypatch):
+    monkeypatch.setattr(
+        "soundcork.admin.list_management_devices",
+        lambda *_args, **_kwargs: management_devices_response(),
+    )
+    monkeypatch.setattr(
+        "soundcork.admin.addr_port_is_reachable",
+        lambda _host, port, timeout=2: port == 17000,
+    )
+
+    client, _speakers = make_client(monkeypatch)
+    response = client.get("/admin/")
+
+    assert response.status_code == 200
+    assert "Status guide" in response.text
+    assert "REST /info" in response.text
+    assert "Telnet CLIServer" in response.text
+    assert "Repair Soundcork routing" in response.text
+    assert f"/admin/switchToSoundcork/{DEVICE_ID}" in response.text
+    assert "B0D5CC0391DB" not in response.text
+    assert "Swtich" not in response.text
+
+
+def test_switch_to_soundcork_uses_telnet_when_ssh_is_unavailable(monkeypatch):
+    called_hosts: list[str] = []
+
+    async def fake_non_rooted(host: str) -> bool:
+        called_hosts.append(host)
+        return True
+
+    def fail_ssh(_host: str) -> bool:
+        raise AssertionError("SSH repair should not be used")
+
+    monkeypatch.setattr(
+        "soundcork.admin.list_management_devices",
+        lambda *_args, **_kwargs: management_devices_response(),
+    )
+    monkeypatch.setattr(
+        "soundcork.admin.addr_port_is_reachable",
+        lambda _host, port, timeout=2: port == 17000,
+    )
+    monkeypatch.setattr("soundcork.admin.override_speaker_config", fail_ssh)
+    monkeypatch.setattr(
+        "soundcork.admin.override_speaker_config_non_rooted", fake_non_rooted
+    )
+    monkeypatch.setattr("soundcork.admin.time.sleep", lambda _seconds: None)
+
+    client, speakers = make_client(monkeypatch)
+    response = client.post(
+        f"/admin/switchToSoundcork/{DEVICE_ID}", follow_redirects=False
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"/admin/wait/{DEVICE_ID}/0"
+    assert called_hosts == [DEVICE_IP]
+    assert speakers.cleared_devices == [DEVICE_ID]

--- a/soundcork/tests/test_admin.py
+++ b/soundcork/tests/test_admin.py
@@ -74,9 +74,15 @@ def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
 
 
 def test_admin_shows_live_marge_and_telnet_repair_action(monkeypatch):
+    list_calls = []
+
+    def fake_list_management_devices(*_args, **kwargs):
+        list_calls.append(kwargs)
+        return management_devices_response()
+
     monkeypatch.setattr(
         "soundcork.admin.list_management_devices",
-        lambda *_args, **_kwargs: management_devices_response(),
+        fake_list_management_devices,
     )
     monkeypatch.setattr(
         "soundcork.admin.addr_port_is_reachable",
@@ -94,6 +100,7 @@ def test_admin_shows_live_marge_and_telnet_repair_action(monkeypatch):
     assert f"/admin/switchToSoundcork/{DEVICE_ID}" in response.text
     assert "B0D5CC0391DB" not in response.text
     assert "Swtich" not in response.text
+    assert list_calls[0]["include_discovered"] is False
 
 
 def test_switch_to_soundcork_uses_telnet_when_ssh_is_unavailable(monkeypatch):

--- a/soundcork/tests/test_admin.py
+++ b/soundcork/tests/test_admin.py
@@ -59,6 +59,9 @@ def management_devices_response(
                 marge_url="https://streaming.bose.com",
                 marge_server=marge_server,
                 uses_this_soundcork=False,
+                internet_radio_ready=False,
+                playback_capability="Needs repair",
+                playback_capability_detail="Radio sources are not ready.",
                 source="datastore",
             )
         ]
@@ -94,9 +97,11 @@ def test_admin_shows_live_marge_and_telnet_repair_action(monkeypatch):
 
     assert response.status_code == 200
     assert "Status guide" in response.text
+    assert "Playback" in response.text
+    assert "Needs repair" in response.text
     assert "REST /info" in response.text
     assert "Telnet CLIServer" in response.text
-    assert "Repair Soundcork routing" in response.text
+    assert "Switch to Soundcork" in response.text
     assert f"/admin/switchToSoundcork/{DEVICE_ID}" in response.text
     assert "B0D5CC0391DB" not in response.text
     assert "Swtich" not in response.text

--- a/soundcork/tests/test_admin.py
+++ b/soundcork/tests/test_admin.py
@@ -130,7 +130,6 @@ def test_switch_to_soundcork_uses_telnet_when_ssh_is_unavailable(monkeypatch):
     monkeypatch.setattr(
         "soundcork.admin.override_speaker_config_non_rooted", fake_non_rooted
     )
-    monkeypatch.setattr("soundcork.admin.time.sleep", lambda _seconds: None)
 
     client, speakers = make_client(monkeypatch)
     response = client.post(
@@ -141,3 +140,17 @@ def test_switch_to_soundcork_uses_telnet_when_ssh_is_unavailable(monkeypatch):
     assert response.headers["location"] == f"/admin/wait/{DEVICE_ID}/0"
     assert called_hosts == [DEVICE_IP]
     assert speakers.cleared_devices == [DEVICE_ID]
+
+
+def test_wait_page_returns_immediately_for_client_side_polling(monkeypatch):
+    monkeypatch.setattr(
+        "soundcork.admin.list_management_devices",
+        lambda *_args, **_kwargs: management_devices_response(),
+    )
+
+    client, _speakers = make_client(monkeypatch)
+    response = client.get(f"/admin/wait/{DEVICE_ID}/0")
+
+    assert response.status_code == 200
+    assert "waiting 0 of 120 seconds" in response.text
+    assert f"url=/admin/wait/{DEVICE_ID}/10" in response.text

--- a/soundcork/tests/test_devices.py
+++ b/soundcork/tests/test_devices.py
@@ -1,0 +1,20 @@
+from soundcork.devices import read_file_from_speaker_http
+
+
+def test_read_file_from_speaker_http_passes_timeout(monkeypatch):
+    calls = []
+
+    class Response:
+        def read(self) -> bytes:
+            return b"<info />"
+
+    def fake_urlopen(url: str, timeout: int):
+        calls.append((url, timeout))
+        return Response()
+
+    monkeypatch.setattr("soundcork.devices.urllib.request.urlopen", fake_urlopen)
+
+    result = read_file_from_speaker_http("192.0.2.10", "/info", timeout=7)
+
+    assert result == "<info />"
+    assert calls == [("http://192.0.2.10:8090/info", 7)]

--- a/soundcork/tests/test_management.py
+++ b/soundcork/tests/test_management.py
@@ -34,6 +34,21 @@ def device_info_xml(
 </info>"""
 
 
+def sources_xml(
+    local_internet_radio_status: str | None = "READY",
+    tunein_status: str | None = "READY",
+) -> str:
+    items = []
+    if tunein_status is not None:
+        items.append(f'<sourceItem source="TUNEIN" status="{tunein_status}" />')
+    if local_internet_radio_status is not None:
+        items.append(
+            '<sourceItem source="LOCAL_INTERNET_RADIO" '
+            f'status="{local_internet_radio_status}" />'
+        )
+    return "<sources>" + "".join(items) + "</sources>"
+
+
 class FakeDatastore:
     def __init__(self):
         self.device = DeviceInfo(
@@ -76,6 +91,7 @@ def test_list_management_devices_refreshes_marge_url_from_speaker_info():
         FakeDatastore(),
         SimpleNamespace(base_url=BASE_URL),
         fetch_info=lambda _host: device_info_xml(),
+        fetch_sources=lambda _host: sources_xml(),
     )
 
     device = response.devices[0]
@@ -87,6 +103,42 @@ def test_list_management_devices_refreshes_marge_url_from_speaker_info():
     assert device.marge_url == f"{BASE_URL}/marge"
     assert device.marge_server == "Soundcork"
     assert device.uses_this_soundcork is True
+    assert device.playback_capability == "Soundcork-ready"
+    assert device.internet_radio_ready is True
+    assert device.source_statuses["LOCAL_INTERNET_RADIO"] == "READY"
+
+
+def test_list_management_devices_reports_bose_legacy_ready_from_sources():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: device_info_xml(marge_url=BOSE_MARGE_URL),
+        fetch_sources=lambda _host: sources_xml(),
+    )
+
+    device = response.devices[0]
+
+    assert device.marge_server == "Bose"
+    assert device.playback_capability == "Legacy-ready"
+    assert "until reboot" in (device.playback_capability_detail or "")
+
+
+def test_list_management_devices_reports_bose_needs_repair_without_radio_sources():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: device_info_xml(marge_url=BOSE_MARGE_URL),
+        fetch_sources=lambda _host: sources_xml(
+            local_internet_radio_status=None,
+            tunein_status=None,
+        ),
+    )
+
+    device = response.devices[0]
+
+    assert device.marge_server == "Bose"
+    assert device.playback_capability == "Needs repair"
+    assert device.internet_radio_ready is False
 
 
 def test_list_management_devices_keeps_stored_device_when_refresh_fails():
@@ -94,6 +146,7 @@ def test_list_management_devices_keeps_stored_device_when_refresh_fails():
         FakeDatastore(),
         SimpleNamespace(base_url=BASE_URL),
         fetch_info=lambda _host: "",
+        fetch_sources=lambda _host: sources_xml(),
     )
 
     device = response.devices[0]
@@ -103,6 +156,7 @@ def test_list_management_devices_keeps_stored_device_when_refresh_fails():
     assert device.marge_url is None
     assert device.marge_server == "Unknown"
     assert device.uses_this_soundcork is False
+    assert device.playback_capability == "Unknown"
 
 
 def test_list_management_devices_reports_unparseable_speaker_info():
@@ -110,6 +164,7 @@ def test_list_management_devices_reports_unparseable_speaker_info():
         FakeDatastore(),
         SimpleNamespace(base_url=BASE_URL),
         fetch_info=lambda _host: "<info>",
+        fetch_sources=lambda _host: sources_xml(),
     )
 
     device = response.devices[0]
@@ -127,6 +182,10 @@ def test_management_devices_endpoint_uses_current_speaker_info(monkeypatch):
         "soundcork.management.read_device_info",
         lambda _host: device_info_xml(marge_url=BOSE_MARGE_URL),
     )
+    monkeypatch.setattr(
+        "soundcork.management.read_runtime_sources",
+        lambda _host: sources_xml(local_internet_radio_status=None, tunein_status=None),
+    )
 
     app = FastAPI()
     app.include_router(router)
@@ -136,3 +195,4 @@ def test_management_devices_endpoint_uses_current_speaker_info(monkeypatch):
     payload = response.json()
     assert payload["devices"][0]["marge_server"] == "Bose"
     assert payload["devices"][0]["uses_this_soundcork"] is False
+    assert payload["devices"][0]["playback_capability"] == "Needs repair"

--- a/soundcork/tests/test_management.py
+++ b/soundcork/tests/test_management.py
@@ -1,0 +1,138 @@
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.management import (
+    BOSE_MARGE_URL,
+    _marge_server,
+    list_management_devices,
+    router,
+)
+from soundcork.model import DeviceInfo
+
+ACCOUNT_ID = "8208423"
+DEVICE_ID = "000C8A123456"
+BASE_URL = "http://unifi:8001"
+
+
+def device_info_xml(
+    marge_url: str = f"{BASE_URL}/marge",
+    account_id: str = ACCOUNT_ID,
+    ip_address: str = "192.168.11.71",
+) -> str:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<info deviceID="{DEVICE_ID}">
+    <name>kuchyn</name>
+    <type>SoundTouch10</type>
+    <moduleType>SM2</moduleType>
+    <networkInfo type="SCM">
+        <ipAddress>{ip_address}</ipAddress>
+    </networkInfo>
+    <margeURL>{marge_url}</margeURL>
+    <margeAccountUUID>{account_id}</margeAccountUUID>
+</info>"""
+
+
+class FakeDatastore:
+    def __init__(self):
+        self.device = DeviceInfo(
+            device_id=DEVICE_ID,
+            product_code="SoundTouch10 SM2",
+            device_serial_number="8675309",
+            product_serial_number="314519",
+            firmware_version="27.0.0",
+            ip_address="192.168.11.71",
+            name="kuchyn",
+            created_on="2026-06-09T00:00:00.000+00:00",
+            updated_on="2026-06-09T00:00:00.000+00:00",
+        )
+
+    def account_exists(self, account_id: str) -> bool:
+        return account_id == ACCOUNT_ID
+
+    def list_accounts(self) -> list[str]:
+        return [ACCOUNT_ID]
+
+    def list_devices(self, account_id: str) -> list[str]:
+        assert account_id == ACCOUNT_ID
+        return [DEVICE_ID]
+
+    def get_device_info(self, account_id: str, device_id: str) -> DeviceInfo:
+        assert account_id == ACCOUNT_ID
+        assert device_id == DEVICE_ID
+        return self.device
+
+
+def test_marge_server_classifies_known_urls():
+    assert _marge_server(None, BASE_URL) == "Unknown"
+    assert _marge_server(BOSE_MARGE_URL, BASE_URL) == "Bose"
+    assert _marge_server(f"{BASE_URL}/marge", BASE_URL) == "Soundcork"
+    assert _marge_server("http://other.example/marge", BASE_URL) == "Other"
+
+
+def test_list_management_devices_refreshes_marge_url_from_speaker_info():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: device_info_xml(),
+    )
+
+    device = response.devices[0]
+
+    assert device.device_id == DEVICE_ID
+    assert device.account_id == ACCOUNT_ID
+    assert device.reported_account_id == ACCOUNT_ID
+    assert device.rest_reachable is True
+    assert device.marge_url == f"{BASE_URL}/marge"
+    assert device.marge_server == "Soundcork"
+    assert device.uses_this_soundcork is True
+
+
+def test_list_management_devices_keeps_stored_device_when_refresh_fails():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: "",
+    )
+
+    device = response.devices[0]
+
+    assert device.device_id == DEVICE_ID
+    assert device.rest_reachable is False
+    assert device.marge_url is None
+    assert device.marge_server == "Unknown"
+    assert device.uses_this_soundcork is False
+
+
+def test_list_management_devices_reports_unparseable_speaker_info():
+    response = list_management_devices(
+        FakeDatastore(),
+        SimpleNamespace(base_url=BASE_URL),
+        fetch_info=lambda _host: "<info>",
+    )
+
+    device = response.devices[0]
+
+    assert device.rest_reachable is False
+    assert device.error == "Unable to parse /info from 192.168.11.71"
+
+
+def test_management_devices_endpoint_uses_current_speaker_info(monkeypatch):
+    monkeypatch.setattr("soundcork.management.datastore", FakeDatastore())
+    monkeypatch.setattr(
+        "soundcork.management.settings", SimpleNamespace(base_url=BASE_URL)
+    )
+    monkeypatch.setattr(
+        "soundcork.management.read_device_info",
+        lambda _host: device_info_xml(marge_url=BOSE_MARGE_URL),
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    response = TestClient(app).get("/mgmt/devices")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["devices"][0]["marge_server"] == "Bose"
+    assert payload["devices"][0]["uses_this_soundcork"] is False

--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -9,7 +9,7 @@ from bosesoundtouchapi.soundtouchclient import (  # type: ignore
     SoundTouchNodes,
 )
 from bosesoundtouchapi.soundtouchdiscovery import SoundTouchDiscovery  # type: ignore
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
@@ -39,6 +39,7 @@ class CombinedDevice(BaseModel):
     - ssh_reachable: The speaker has SSH open on port 22.
     - telnet_reachable: The speaker has the SoundTouch CLIServer open on port 17000.
     - repair_available: Soundcork can try to point Bose URLs at this instance.
+    - playback_capability: Whether internet radio playback is currently usable.
     - st_device: SoundTouchDevice instance as discovered by BoseSoundTouchApi
     """
 
@@ -57,6 +58,10 @@ class CombinedDevice(BaseModel):
     telnet_reachable: bool = False
     repair_available: bool = False
     marge_url: str | None = None
+    source_statuses: dict[str, str] = Field(default_factory=dict)
+    internet_radio_ready: bool | None = None
+    playback_capability: str = "Unknown"
+    playback_capability_detail: str | None = None
     state_source: str = "discovery"
     error: str | None = None
 

--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -34,6 +34,11 @@ class CombinedDevice(BaseModel):
     - in_soundcork: In the soundcork datastore
     - marge_server: API this speaker uses for Marge: (ie. Bose, or this Soundcork instance)
     - reachable:  Has been configured (ie. with a USB key) to have shell-access available.
+      Equivalent to ssh_reachable and kept for compatibility.
+    - rest_reachable: The speaker's HTTP /info endpoint responded.
+    - ssh_reachable: The speaker has SSH open on port 22.
+    - telnet_reachable: The speaker has the SoundTouch CLIServer open on port 17000.
+    - repair_available: Soundcork can try to point Bose URLs at this instance.
     - st_device: SoundTouchDevice instance as discovered by BoseSoundTouchApi
     """
 
@@ -47,6 +52,13 @@ class CombinedDevice(BaseModel):
     reachable: bool
     st_device: SoundTouchDevice | None
     language_code: str | None = None
+    rest_reachable: bool = False
+    ssh_reachable: bool = False
+    telnet_reachable: bool = False
+    repair_available: bool = False
+    marge_url: str | None = None
+    state_source: str = "discovery"
+    error: str | None = None
 
     class Config:
         arbitrary_types_allowed = True


### PR DESCRIPTION
## Summary

This PR makes the admin page use live speaker state when deciding whether a device is already using Soundcork, still using Bose URLs, or needs to be switched to this Soundcork instance.

It adds a management-device inventory layer that reads each speaker's `/info` and `/sources` responses, exposes the same data through a JSON management endpoint, and shows more explicit admin columns for Live Marge, Playback, REST `/info`, SSH, and Telnet CLIServer reachability.

It also keeps the `Switch to Soundcork` restart/wait flow non-blocking: after a switch attempt, the server redirects to the existing wait page immediately and lets the browser poll through the page's meta refresh instead of holding a worker for tens of seconds.

## Why

The previous admin view primarily relied on stored/discovered state and a single `Reachable` concept. That makes it hard to distinguish a speaker that is still pointing at Bose but currently has working radio sources from one that has already lost those sources after a reboot.

It also hides a useful recovery path: some non-rooted speakers expose the SoundTouch CLIServer on port 17000. When SSH is unavailable but CLIServer is reachable, Soundcork can ask the speaker to update its Bose URLs and reboot without requiring root access.

Finally, the admin switch flow should not block the server while waiting for a speaker restart. A single-worker deployment can otherwise hit Gunicorn's worker timeout and temporarily make the admin UI, management API, and Marge endpoints unavailable.

## Implementation Details

- Add `soundcork/management.py` to build a live management view from stored Soundcork devices, discovery data, speaker `/info`, and speaker `/sources`.
- Add `/mgmt/devices` so the live management state is available as JSON instead of only through the admin HTML.
- Split admin reachability into REST `/info`, SSH, and Telnet CLIServer columns.
- Keep the action label as `Switch to Soundcork`, matching the existing README wording, while allowing the action when either SSH or Telnet CLIServer is available.
- Add short timeouts so offline or cross-network devices do not block the admin page for a long time.
- Let `/admin/wait/{device_id}/{elapsed}` return immediately and rely on the existing wait-page meta refresh for polling.
- Preserve existing miniapp behavior by keeping selected-device validation focused on Soundcork-managed devices.

## Tests

Ran:

```sh
.venv/bin/pytest -q
```

Result: `40 passed`.

## Compatibility and Scope

The existing `/admin/switchToSoundcork/{device_id}` route remains in place. For SSH-reachable speakers it continues to use the existing XML override path. For non-rooted speakers with CLIServer available, it uses the existing non-rooted override helper.

This PR does not change preset migration, SoundTouch playback behavior, or the Miniapp's device-control model.
