### PR TITLE
Allow moving configured devices between accounts

### DIFF
--- a/soundcork/admin.py
+++ b/soundcork/admin.py
@@ -36,6 +36,70 @@ router = APIRouter(tags=["admin"])
 logger = logging.getLogger(__name__)
 
 
+def _device_accounts(datastore: DataStore, device_id: str) -> list[str]:
+    accounts = []
+    for account_id in datastore.list_accounts():
+        if account_id and datastore.device_exists(account_id, device_id):
+            accounts.append(account_id)
+    return accounts
+
+
+def _remove_device_from_other_accounts(
+    datastore: DataStore,
+    device_id: str,
+    target_account: str,
+) -> None:
+    for account_id in _device_accounts(datastore, device_id):
+        if account_id == target_account:
+            continue
+        group = datastore.group_for_device(account_id, device_id)
+        if group:
+            datastore.delete_group(account_id, group.id)
+        datastore.remove_device(account_id, device_id)
+
+
+def _set_device_account(
+    datastore: DataStore,
+    speakers: Speakers,
+    device_id: str,
+    account_id: str,
+) -> bool:
+    if not datastore.account_exists(account_id):
+        logger.warning(
+            "cannot move %s: account %s does not exist", device_id, account_id
+        )
+        return False
+
+    combined_device = speakers.all_devices().get(device_id)
+    if not combined_device or not combined_device.st_device:
+        logger.warning("cannot move %s: device is not online", device_id)
+        return False
+
+    hostname = combined_device.st_device.Host
+    reachable = addr_is_reachable(hostname)
+    if not speakers.set_account(device_id, account_id):
+        logger.warning("cannot move %s: speaker rejected setMargeAccount", device_id)
+        return False
+
+    if not add_device_by_ip(hostname, reachable):
+        logger.warning(
+            "cannot move %s: failed to import device from %s", device_id, hostname
+        )
+        return False
+
+    if not datastore.device_exists(account_id, device_id):
+        logger.warning(
+            "cannot move %s: imported device is not stored under account %s",
+            device_id,
+            account_id,
+        )
+        return False
+
+    _remove_device_from_other_accounts(datastore, device_id, account_id)
+    speakers.clear_device(device_id)
+    return True
+
+
 def get_admin_router(datastore: DataStore, speakers: Speakers):
     from fastapi.responses import HTMLResponse
     from fastapi.templating import Jinja2Templates
@@ -207,7 +271,13 @@ def get_admin_router(datastore: DataStore, speakers: Speakers):
     async def set_account(
         request: Request, device_id: str, account_id: Annotated[str, Form()]
     ):
-        success = speakers.set_account(device_id, account_id)
+        success = _set_device_account(datastore, speakers, device_id, account_id)
+        logger.info(
+            "set account for %s to %s success=%s",
+            device_id,
+            account_id,
+            success,
+        )
         return RedirectResponse(url="/admin/", status_code=HTTPStatus.FOUND)
 
     @router.get("/admin/edit_device/{device_id}")

--- a/soundcork/templates/admin/admin_main.html
+++ b/soundcork/templates/admin/admin_main.html
@@ -45,6 +45,26 @@
                             <input type="submit" value="Switch to Soundcork">
                         </form>
                         {% endif %}
+                        {% if account.in_soundcork and device.in_soundcork %}
+                        {% set target_accounts = namespace(count=0) %}
+                        {% for target_id, target_account in accounts.items() %}
+                            {% if target_account.in_soundcork and target_id != account.id %}
+                            {% set target_accounts.count = target_accounts.count + 1 %}
+                            {% endif %}
+                        {% endfor %}
+                        {% if target_accounts.count > 0 %}
+                        <form class="inline-form" action="/admin/{{device.id}}/setAccount" method="POST">
+                            <select name="account_id">
+                            {% for target_id, target_account in accounts.items() %}
+                                {% if target_account.in_soundcork and target_id != account.id %}
+                                <option value="{{target_id}}">{{target_id}}</option>
+                                {% endif %}
+                            {% endfor %}
+                            </select>
+                            <input type="submit" value="Move to Account">
+                        </form>
+                        {% endif %}
+                        {% endif %}
                     </td>
             {% endfor %}
             </tbody>

--- a/soundcork/tests/test_admin.py
+++ b/soundcork/tests/test_admin.py
@@ -1,0 +1,159 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.admin import _set_device_account, get_admin_router
+from soundcork.model import Group
+
+DEVICE_ID = "506583D69BA0"
+SOURCE_ACCOUNT = "5700454"
+TARGET_ACCOUNT = "8208423"
+
+
+class FakeStDevice:
+    def __init__(self, host: str = "192.0.2.10"):
+        self.Host = host
+
+
+@dataclass
+class FakeCombinedDevice:
+    id: str = DEVICE_ID
+    ip: str = "192.0.2.10"
+    name: str = "SoundTouch 10"
+    online: bool = True
+    account: str | None = SOURCE_ACCOUNT
+    in_soundcork: bool = True
+    marge_server: str = "Soundcork"
+    reachable: bool = False
+    st_device: FakeStDevice | None = None
+    language_code: str | None = None
+
+
+class FakeDatastore:
+    def __init__(self):
+        self.accounts = {
+            SOURCE_ACCOUNT: {DEVICE_ID},
+            TARGET_ACCOUNT: set(),
+        }
+        self.deleted_groups = []
+        self.removed_devices = []
+        self.group = Group(
+            id="1234567",
+            name="Old stereo pair",
+            master_id=DEVICE_ID,
+            left_id=DEVICE_ID,
+            left_ip="192.0.2.10",
+            right_id="304511A02B11",
+            right_ip="192.0.2.11",
+        )
+
+    def list_accounts(self):
+        return list(self.accounts)
+
+    def account_exists(self, account_id):
+        return account_id in self.accounts
+
+    def device_exists(self, account_id, device_id):
+        return device_id in self.accounts.get(account_id, set())
+
+    def group_for_device(self, account_id, device_id):
+        if account_id == SOURCE_ACCOUNT and self.device_exists(account_id, device_id):
+            return self.group
+        return None
+
+    def delete_group(self, account_id, group_id):
+        self.deleted_groups.append((account_id, group_id))
+
+    def remove_device(self, account_id, device_id):
+        self.removed_devices.append((account_id, device_id))
+        self.accounts[account_id].discard(device_id)
+        return True
+
+
+class FakeSpeakers:
+    def __init__(self, device: FakeCombinedDevice | None = None):
+        self.device = device or FakeCombinedDevice(st_device=FakeStDevice())
+        self.set_account_calls = []
+        self.clear_device_calls = []
+
+    def all_devices(self):
+        return {self.device.id: self.device}
+
+    def set_account(self, device_id, account_id):
+        self.set_account_calls.append((device_id, account_id))
+        return True
+
+    def clear_device(self, device_id):
+        self.clear_device_calls.append(device_id)
+
+
+def make_client(monkeypatch, datastore=None, speakers=None):
+    monkeypatch.chdir(Path(__file__).parents[1])
+    monkeypatch.setattr("soundcork.admin.addr_is_reachable", lambda _: False)
+    app = FastAPI()
+    app.include_router(
+        get_admin_router(
+            datastore or FakeDatastore(),
+            speakers or FakeSpeakers(),
+        )
+    )
+    return TestClient(app)
+
+
+def test_admin_shows_move_account_for_configured_device(monkeypatch):
+    client = make_client(monkeypatch)
+
+    response = client.get("/admin/")
+
+    assert response.status_code == 200
+    assert f'action="/admin/{DEVICE_ID}/setAccount"' in response.text
+    assert '<input type="submit" value="Move to Account">' in response.text
+    assert (
+        f'<option value="{TARGET_ACCOUNT}">{TARGET_ACCOUNT}</option>' in response.text
+    )
+    assert (
+        f'<option value="{SOURCE_ACCOUNT}">{SOURCE_ACCOUNT}</option>'
+        not in response.text
+    )
+
+
+def test_set_device_account_imports_target_then_removes_old(monkeypatch):
+    datastore = FakeDatastore()
+    speakers = FakeSpeakers()
+    monkeypatch.setattr("soundcork.admin.addr_is_reachable", lambda _: True)
+
+    def add_device_by_ip(hostname, reachable):
+        assert hostname == "192.0.2.10"
+        assert reachable is True
+        datastore.accounts[TARGET_ACCOUNT].add(DEVICE_ID)
+        return True
+
+    monkeypatch.setattr("soundcork.admin.add_device_by_ip", add_device_by_ip)
+
+    success = _set_device_account(datastore, speakers, DEVICE_ID, TARGET_ACCOUNT)
+
+    assert success is True
+    assert speakers.set_account_calls == [(DEVICE_ID, TARGET_ACCOUNT)]
+    assert datastore.device_exists(TARGET_ACCOUNT, DEVICE_ID)
+    assert not datastore.device_exists(SOURCE_ACCOUNT, DEVICE_ID)
+    assert datastore.deleted_groups == [(SOURCE_ACCOUNT, "1234567")]
+    assert datastore.removed_devices == [(SOURCE_ACCOUNT, DEVICE_ID)]
+    assert speakers.clear_device_calls == [DEVICE_ID]
+
+
+def test_set_device_account_does_not_cleanup_if_import_misses_target(monkeypatch):
+    datastore = FakeDatastore()
+    speakers = FakeSpeakers()
+    monkeypatch.setattr("soundcork.admin.addr_is_reachable", lambda _: False)
+    monkeypatch.setattr("soundcork.admin.add_device_by_ip", lambda *_: True)
+
+    success = _set_device_account(datastore, speakers, DEVICE_ID, TARGET_ACCOUNT)
+
+    assert success is False
+    assert speakers.set_account_calls == [(DEVICE_ID, TARGET_ACCOUNT)]
+    assert datastore.device_exists(SOURCE_ACCOUNT, DEVICE_ID)
+    assert datastore.deleted_groups == []
+    assert datastore.removed_devices == []
+    assert speakers.clear_device_calls == []


### PR DESCRIPTION
Title: Allow moving configured devices between accounts

## Summary

This adds an admin UI action for moving an already configured SoundTouch device from one Soundcork account to another.

## Rationale

The admin page already supports assigning an unassociated device to an account through `/admin/{device_id}/setAccount`, and `Speakers.set_account()` already sends the SoundTouch `setMargeAccount` request to the speaker. However, once a device is already present in the Soundcork datastore, there is no admin action to move it to another existing account.

This matters when a speaker was recovered or added under a temporary or different account ID and then needs to be associated with the account whose presets, sources, and group metadata the user actually wants to use.

## Implementation Details

- Shows a `Move to Account` form for configured devices when at least one other Soundcork account exists.
- Reuses the existing `/admin/{device_id}/setAccount` endpoint.
- Verifies that the requested target account exists before touching the speaker.
- Calls the existing `Speakers.set_account()` path to send `setMargeAccount` to the device.
- Reimports the device from the live speaker state with `add_device_by_ip()`.
- Removes the old datastore association only after the device exists under the target account.
- Deletes any old stereo group entry that referenced the moved device before removing the old device association.
- Clears the speaker discovery cache after a successful move.

## Tests and Validation

- Added admin tests covering:
  - rendering the `Move to Account` action for configured devices;
  - successful move sequencing, including old group cleanup;
  - no old-account cleanup if the live speaker import does not create the target-account device.
- Ran `black --target-version py312 --check soundcork/admin.py soundcork/tests/test_admin.py`.
- Ran `isort --check-only soundcork/admin.py soundcork/tests/test_admin.py`.
- Ran `git diff --check`.
- Ran the full test suite with `pytest -q`: 32 passed, with one existing Pydantic deprecation warning.
- Also live-tested the flow on a UDR-hosted Soundcork instance with a recovered SoundTouch 10: after submitting the admin form, the speaker's `/info` reported the new account, the management view showed the new account association, the old account group endpoint stopped matching that device, and creating a stereo pair with that speaker subsequently succeeded.

## Compatibility and Risk

This is limited to the admin page and the existing account assignment endpoint. It does not change normal playback, miniapp behavior, BMX/Marge endpoints, discovery, or account creation.

The old datastore association is intentionally kept unless the target account import succeeds, so a failed move should not orphan the device in Soundcork.

## Non-Goals

- This does not add account renaming or friendly account labels.
- This does not change how accounts are discovered or created.
- This does not migrate presets or sources between accounts.
- This does not expose a public JSON management API for account moves.
