### PR TITLE
Fix SoundTouch group Marge compatibility

### DIFF
--- a/soundcork/datastore.py
+++ b/soundcork/datastore.py
@@ -758,25 +758,34 @@ class DataStore:
             if not path.exists(filepath):
                 return group_id
 
+    def _normalize_group_id(self, group_id: str) -> str:
+        """Return the bare 7-digit group id from an id or Group_<id>.xml name."""
+        if group_id.startswith("Group_") and group_id.endswith(".xml"):
+            return group_id[len("Group_") : -len(".xml")]
+        return group_id
+
     def list_groups(self, account: str) -> list[Group]:
         """list all existing groups"""
         devices_dir = self.account_devices_dir(account)
+        if not path.exists(devices_dir):
+            return []
         groups = []
         for fn in listdir(devices_dir):
             if fn.startswith("Group_") and fn.endswith(".xml"):
-                group = self.get_group(account, fn)
+                group = self.get_group(account, self._normalize_group_id(fn))
                 if group:
                     groups.append(group)
         return groups
 
     def group_exists(self, account: str, group_id: str) -> bool:
         """check if a group with given id exist"""
+        group_id = self._normalize_group_id(group_id)
         return path.exists(
             path.join(self.account_devices_dir(account), f"Group_{group_id}.xml")
         )
 
     def device_is_groupable(self, device_info: DeviceInfo) -> bool:
-        return device_info.product_code == "SoundTouch 10"
+        return device_info.product_code.lower().startswith("soundtouch 10")
 
     def add_group(self, account: str, group: Group) -> ET.Element:
         """adds a group
@@ -790,6 +799,11 @@ class DataStore:
         group_id = self._generate_group_id(account)
         group.id = group_id
         device_ids = [group.left_id, group.right_id]
+        if not group.master_id or not group.left_id or not group.right_id:
+            raise HTTPException(
+                HTTPStatus.BAD_REQUEST,
+                "Group requires masterDeviceId plus LEFT and RIGHT deviceId roles",
+            )
         # -- are these already grouped?
         for dev_id in device_ids:
             existing_group = self.group_for_device(account, dev_id)
@@ -811,6 +825,10 @@ class DataStore:
                     HTTPStatus.BAD_REQUEST,
                     f"Device {dev_id} is not of type 'SoundTouch 10'",
                 )
+            if dev_id == group.left_id and not group.left_ip:
+                group.left_ip = device_info.ip_address
+            if dev_id == group.right_id and not group.right_ip:
+                group.right_ip = device_info.ip_address
 
         return self.save_group(account, group_id, group)
 
@@ -832,6 +850,7 @@ class DataStore:
 
     def get_group(self, account: str, group_id: str) -> Group | None:
         """Gets a group from the account files in the datastore"""
+        group_id = self._normalize_group_id(group_id)
         filename = f"Group_{group_id}.xml"
         filepath = path.join(self.account_devices_dir(account), filename)
         if path.exists(filepath):
@@ -849,6 +868,7 @@ class DataStore:
         - Empty string on success
         - raises exception if group doesn't exist or if there's an error deleting the file
         """
+        group_id = self._normalize_group_id(group_id)
         filename = f"Group_{group_id}.xml"
         filepath = path.join(self.account_devices_dir(account), filename)
 
@@ -866,6 +886,16 @@ class DataStore:
                 f"Failed to delete group {group_id}: {e}",
             )
 
+        return ""
+
+    def delete_all_groups(self, account: str) -> str:
+        """Delete every stored group for an account."""
+        devices_dir = self.account_devices_dir(account)
+        if not path.exists(devices_dir):
+            return ""
+        for fn in listdir(devices_dir):
+            if fn.startswith("Group_") and fn.endswith(".xml"):
+                remove(path.join(devices_dir, fn))
         return ""
 
     def group_for_device(self, account: str, device_id: str) -> Group | None:
@@ -892,7 +922,8 @@ class DataStore:
 
     def group_to_xml(self, group: Group) -> ET.Element:
         """Converts a Group object to an XML element for storage."""
-        group_elem = ET.Element("group")
+        attrs = {"id": group.id} if group.id else {}
+        group_elem = ET.Element("group", attrs)
         ET.SubElement(group_elem, "name").text = group.name
         ET.SubElement(group_elem, "masterDeviceId").text = group.master_id
         roles = ET.SubElement(group_elem, "roles")
@@ -910,12 +941,17 @@ class DataStore:
 
     def group_from_xml(self, group_id: str, group_elem: ET.Element) -> Group:
         """Converts an XML element into a Group object."""
+        group_id = group_id or group_elem.get("id") or ""
         name = strip_element_text(group_elem.find("name"))
         master_id = strip_element_text(group_elem.find("masterDeviceId"))
         roles_elem = group_elem.find("roles")
+        left_id = ""
+        left_ip = ""
+        right_id = ""
+        right_ip = ""
         if not roles_elem == None:
             for role_elem in roles_elem.findall("groupRole"):
-                role = strip_element_text(role_elem.find("role"))
+                role = strip_element_text(role_elem.find("role")).upper()
                 if role == "LEFT":
                     left_id = strip_element_text(role_elem.find("deviceId"))
                     left_ip = strip_element_text(role_elem.find("ipAddress"))

--- a/soundcork/groups.py
+++ b/soundcork/groups.py
@@ -24,14 +24,37 @@ BOSE_UPDATEGROUP = "/updateGroup"  # POST + XML
 BOSE_REMOVEGROUP = "/removeGroup"  # GET
 
 
+def _bose_xml_str(xml: ET.Element) -> str:
+    return f'<?xml version="1.0" encoding="UTF-8" standalone="yes"?>{ET.tostring(xml, encoding="unicode")}'
+
+
 # ----------------------------------------------------------------------
 # Factory: creates router with access to datastore (Dependency Injection)
 # ----------------------------------------------------------------------
 def get_groups_router(datastore):
     marge = APIRouter(tags=["marge"])
 
-    from soundcork.main import bose_xml_str
+    @marge.get(
+        "/marge/streaming/account/{account}/groups",
+        response_class=BoseXMLResponse,
+        tags=["marge"],
+    )
+    async def account_groups(
+        account: Annotated[str, Path(pattern=ACCOUNT_RE)],
+    ):
+        """marge group endpoint to list all groups for an account"""
 
+        groups_elem = ET.Element("groups")
+        for group in datastore.list_groups(account):
+            groups_elem.append(datastore.group_to_xml(group))
+
+        return _bose_xml_str(groups_elem)
+
+    @marge.get(
+        "/marge/streaming/account/{account}/device/{device}/group/",
+        response_class=BoseXMLResponse,
+        tags=["marge"],
+    )
     @marge.get(
         "/marge/streaming/account/{account}/device/{device}/group",
         response_class=BoseXMLResponse,
@@ -45,8 +68,13 @@ def get_groups_router(datastore):
 
         result = get_device_group_xml(datastore, account, device)
 
-        return bose_xml_str(result)
+        return _bose_xml_str(result)
 
+    @marge.post(
+        "/marge/streaming/account/{account}/group/",
+        response_class=BoseXMLResponse,
+        tags=["marge"],
+    )
     @marge.post(
         "/marge/streaming/account/{account}/group",
         response_class=BoseXMLResponse,
@@ -55,15 +83,28 @@ def get_groups_router(datastore):
     async def add_group_endpoint(
         account: Annotated[str, Path(pattern=ACCOUNT_RE)],
         request: Request,
+        response: Response,
     ) -> str:
 
         reqxml_bytes = await request.body()
         reqxml_str = reqxml_bytes.decode("utf-8")
 
         result = add_group(datastore, account, reqxml_str)
+        response.status_code = HTTPStatus.CREATED
+        group_id = result.get("id")
+        if group_id:
+            base_url = str(request.base_url).rstrip("/")
+            response.headers["Location"] = (
+                f"{base_url}/marge/streaming/account/{account}/group/{group_id}"
+            )
 
-        return bose_xml_str(result)
+        return _bose_xml_str(result)
 
+    @marge.put(
+        "/marge/streaming/account/{account}/group/{group}",
+        response_class=BoseXMLResponse,
+        tags=["marge"],
+    )
     @marge.post(
         "/marge/streaming/account/{account}/group/{group}",
         response_class=BoseXMLResponse,
@@ -81,7 +122,7 @@ def get_groups_router(datastore):
             xml_str = body.decode("utf-8")
             result = modify_group(datastore, account, group, xml_str)
 
-            return bose_xml_str(result)
+            return _bose_xml_str(result)
 
         except ET.ParseError:
             response.status_code = HTTPStatus.BAD_REQUEST
@@ -89,6 +130,30 @@ def get_groups_router(datastore):
         except UnicodeDecodeError:
             response.status_code = HTTPStatus.BAD_REQUEST
             return "<error>Invalid UTF-8 in request body</error>"
+
+    @marge.delete(
+        "/marge/streaming/account/{account}/group/",
+        response_class=BoseXMLResponse,
+        tags=["marge"],
+    )
+    async def delete_account_groups_endpoint(
+        account: Annotated[str, Path(pattern=ACCOUNT_RE)],
+    ):
+        """marge group endpoint to delete all account groups"""
+        try:
+            error = datastore.delete_all_groups(account)
+            if error:
+                return BoseXMLResponse(
+                    content=f"<error>{error}</error>",
+                    status_code=HTTPStatus.BAD_REQUEST,
+                )
+            return BoseXMLResponse(
+                content="<status>Groups deleted successfully</status>"
+            )
+        except Exception as e:
+            return BoseXMLResponse(
+                content=f"<error>Unexpected error: {e}</error>", status_code=500
+            )
 
     @marge.delete(
         "/marge/streaming/account/{account}/group/{group}",

--- a/soundcork/groups_service.py
+++ b/soundcork/groups_service.py
@@ -130,13 +130,14 @@ def _group_xml_by_id(datastore, account: str, groupid: str) -> str:
 
 
 def _group_id_by_name(datastore, account: str, name: str) -> Optional[str]:
-    for gid in datastore.list_groups(account):
+    for group in datastore.list_groups(account):
         try:
-            xml = _group_xml_by_id(datastore, account, gid)
+            group_id = group.id
+            xml = _group_xml_by_id(datastore, account, group_id)
             root = ET.fromstring(xml.strip())
             nm = (root.findtext("name") or "").strip()
             if nm == name:
-                return gid
+                return group_id
         except Exception:
             continue
     return None

--- a/soundcork/marge.py
+++ b/soundcork/marge.py
@@ -546,7 +546,7 @@ def get_device_group_xml(
     if group:
         return datastore.group_to_xml(group)
     else:
-        return ET.Element("groups")
+        return ET.Element("group")
 
 
 def add_group(datastore: "DataStore", account: str, group_info_xml: str) -> ET.Element:

--- a/soundcork/tests/test_groups.py
+++ b/soundcork/tests/test_groups.py
@@ -1,0 +1,182 @@
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from soundcork.constants import DEVICE_INFO_FILE
+from soundcork.datastore import DataStore
+from soundcork.groups import get_groups_router
+from soundcork.groups_service import _group_id_by_name
+from soundcork.marge import get_device_group_xml
+
+
+def _datastore(tmp_path: Path, monkeypatch) -> DataStore:
+    monkeypatch.setattr("soundcork.datastore.settings.data_dir", str(tmp_path))
+    return DataStore()
+
+
+def _write_st10(
+    datastore: DataStore,
+    account: str,
+    device_id: str,
+    ip_address: str,
+    name: str,
+    product_code: str = "SoundTouch 10 sm2",
+) -> None:
+    device_dir = Path(datastore.account_devices_dir(account)) / device_id
+    device_dir.mkdir(parents=True, exist_ok=True)
+    (device_dir / DEVICE_INFO_FILE).write_text(
+        f"""
+        <info deviceID="{device_id}">
+            <name>{name}</name>
+            <type>{product_code}</type>
+            <components>
+                <component>
+                    <componentCategory>SCM</componentCategory>
+                    <softwareVersion>27.0.0</softwareVersion>
+                    <serialNumber>{device_id}</serialNumber>
+                </component>
+                <component>
+                    <componentCategory>PackagedProduct</componentCategory>
+                    <serialNumber>{device_id}</serialNumber>
+                </component>
+            </components>
+            <networkInfo type="SCM">
+                <macAddress>{device_id}</macAddress>
+                <ipAddress>{ip_address}</ipAddress>
+            </networkInfo>
+        </info>
+        """,
+        encoding="utf-8",
+    )
+
+
+def _group_payload(
+    left_id: str = "AABBCCDDEEFF",
+    right_id: str = "112233445566",
+) -> str:
+    return f"""
+    <group>
+        <name>Loznice pair</name>
+        <masterDeviceId>{left_id}</masterDeviceId>
+        <roles>
+            <groupRole>
+                <deviceId>{left_id}</deviceId>
+                <role>LEFT</role>
+            </groupRole>
+            <groupRole>
+                <deviceId>{right_id}</deviceId>
+                <role>RIGHT</role>
+            </groupRole>
+        </roles>
+    </group>
+    """
+
+
+def test_group_datastore_roundtrip_uses_group_id_from_filename(tmp_path, monkeypatch):
+    account = "12345"
+    left_id = "AABBCCDDEEFF"
+    right_id = "112233445566"
+    datastore = _datastore(tmp_path, monkeypatch)
+    _write_st10(datastore, account, left_id, "192.0.2.10", "Left")
+    _write_st10(datastore, account, right_id, "192.0.2.11", "Right")
+
+    group = datastore.group_from_xml("", ET.fromstring(_group_payload()))
+    group_xml = datastore.add_group(account, group)
+
+    group_id = group_xml.get("id")
+    assert group_id
+    assert (tmp_path / account / "devices" / f"Group_{group_id}.xml").exists()
+
+    groups = datastore.list_groups(account)
+    assert [group.id for group in groups] == [group_id]
+    assert groups[0].left_ip == "192.0.2.10"
+    assert groups[0].right_ip == "192.0.2.11"
+    assert datastore.group_for_device(account, left_id).id == group_id
+    assert datastore.group_to_xml(groups[0]).get("id") == group_id
+
+
+def test_get_device_group_xml_returns_empty_group_for_ungrouped_st10(
+    tmp_path, monkeypatch
+):
+    account = "12345"
+    device_id = "AABBCCDDEEFF"
+    datastore = _datastore(tmp_path, monkeypatch)
+    _write_st10(datastore, account, device_id, "192.0.2.10", "Left")
+
+    group_xml = get_device_group_xml(datastore, account, device_id)
+
+    assert group_xml.tag == "group"
+    assert group_xml.attrib == {}
+    assert list(group_xml) == []
+
+
+def test_group_service_resolves_group_id_by_name(tmp_path, monkeypatch):
+    account = "12345"
+    left_id = "AABBCCDDEEFF"
+    right_id = "112233445566"
+    datastore = _datastore(tmp_path, monkeypatch)
+    _write_st10(datastore, account, left_id, "192.0.2.10", "Left")
+    _write_st10(datastore, account, right_id, "192.0.2.11", "Right")
+    group = datastore.group_from_xml("", ET.fromstring(_group_payload()))
+    group_xml = datastore.add_group(account, group)
+
+    assert _group_id_by_name(datastore, account, "Loznice pair") == group_xml.get("id")
+
+
+def test_marge_group_routes_match_stockholm_and_speaker_shapes(tmp_path, monkeypatch):
+    account = "12345"
+    left_id = "AABBCCDDEEFF"
+    right_id = "112233445566"
+    datastore = _datastore(tmp_path, monkeypatch)
+    _write_st10(datastore, account, left_id, "192.0.2.10", "Left")
+    _write_st10(datastore, account, right_id, "192.0.2.11", "Right")
+    app = FastAPI()
+    app.include_router(get_groups_router(datastore))
+    client = TestClient(app)
+
+    created = client.post(
+        f"/marge/streaming/account/{account}/group/",
+        content=_group_payload(),
+        headers={"Content-Type": "application/vnd.bose.streaming-v1.2+xml"},
+    )
+
+    assert created.status_code == 201
+    created_xml = ET.fromstring(created.text)
+    group_id = created_xml.get("id")
+    assert group_id
+    assert created.headers["location"].endswith(f"/group/{group_id}")
+
+    device_group = client.get(
+        f"/marge/streaming/account/{account}/device/{left_id}/group/"
+    )
+    assert device_group.status_code == 200
+    assert ET.fromstring(device_group.text).get("id") == group_id
+
+    groups = client.get(f"/marge/streaming/account/{account}/groups")
+    assert groups.status_code == 200
+    groups_xml = ET.fromstring(groups.text)
+    assert groups_xml.tag == "groups"
+    assert groups_xml.find("group").get("id") == group_id
+
+    renamed = client.put(
+        f"/marge/streaming/account/{account}/group/{group_id}",
+        content=f"""
+        <group id="{group_id}">
+            <name>Renamed pair</name>
+            <masterDeviceId>{left_id}</masterDeviceId>
+        </group>
+        """,
+    )
+    assert renamed.status_code == 200
+    assert ET.fromstring(renamed.text).findtext("name") == "Renamed pair"
+
+    deleted = client.delete(f"/marge/streaming/account/{account}/group/")
+    assert deleted.status_code == 200
+    assert datastore.list_groups(account) == []
+
+    ungrouped = client.get(f"/marge/streaming/account/{account}/device/{left_id}/group")
+    assert ungrouped.status_code == 200
+    assert ET.fromstring(ungrouped.text).tag == "group"
+    assert list(ET.fromstring(ungrouped.text)) == []


### PR DESCRIPTION
Title: Fix SoundTouch group Marge compatibility

## Summary

This improves the Marge group endpoints used by SoundTouch 10 stereo-pair setup flows.

## Rationale

The current group implementation is close, but a real SoundTouch/Stockholm stereo-pair flow expects a few additional response and route shapes:

- an ungrouped device query should return an empty `<group/>`, not `<groups/>`;
- stored groups should round-trip with a group `id`;
- group creation should return a location for the newly created group;
- speakers and the Stockholm app may use trailing-slash route variants;
- the Marge API may be asked for an account-level group list.

Without these details, the application can complete parts of the pairing flow but fail to persist or retrieve the group state in the shape expected by the original Bose clients.

## Implementation Details

- Adds `GET /marge/streaming/account/{account}/groups`.
- Accepts trailing-slash variants for per-device group lookup and group creation.
- Returns `<group/>` for ungrouped devices.
- Includes the generated group id in serialized group XML.
- Returns `201 Created` and a `Location` header when creating a group.
- Accepts `PUT` as well as `POST` for updating an existing group.
- Adds `DELETE /marge/streaming/account/{account}/group/` to clear account groups.
- Normalizes group IDs so datastore callers can pass either a bare id or a `Group_<id>.xml` filename.
- Backfills missing role IP addresses from the stored device info.
- Treats product codes beginning with `SoundTouch 10` as groupable.
- Fixes the existing group service name lookup to use the `Group.id` value returned by `list_groups()`.

## Tests and Validation

- Added `soundcork/tests/test_groups.py` covering:
  - datastore group round-tripping with generated ids;
  - `<group/>` for ungrouped ST10 devices;
  - Marge route shapes used by Stockholm and SoundTouch speakers;
  - group lookup by name in the group service helper.
- Ran `black --target-version py312 --check soundcork/datastore.py soundcork/groups.py soundcork/groups_service.py soundcork/marge.py soundcork/tests/test_groups.py`.
- Ran `isort --check-only soundcork/datastore.py soundcork/groups.py soundcork/groups_service.py soundcork/marge.py soundcork/tests/test_groups.py`.
- Ran `git diff --check`.
- Ran the full test suite with `pytest -q`: 33 passed, with one existing Pydantic deprecation warning.
- Also live-tested this on a UDR-hosted Soundcork instance with two SoundTouch 10 speakers. After both speakers were associated with the same account, creating a stereo pair through the Stockholm UI succeeded.

## Compatibility and Risk

This is limited to SoundTouch group metadata handling and Marge group endpoint compatibility. It does not change normal playback, account creation, presets, sources, Spotify handling, or miniapp behavior.

The datastore changes are backwards-compatible with existing `Group_<id>.xml` files and keep accepting the existing bare-id call style.

## Non-Goals

- This does not add a new end-user group-management UI.
- This does not implement or change the Stockholm stereo-pair wizard.
- This does not change speaker-to-speaker zone playback.
- This does not depend on UniFi-specific deployment behavior.
