### PR TITLE
Tolerate ENODEV during initial SoundTouch discovery

### DIFF
--- a/soundcork/tests/test_speakers.py
+++ b/soundcork/tests/test_speakers.py
@@ -1,0 +1,56 @@
+import errno
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from soundcork.config import Settings
+from soundcork.ui.speakers import Speakers
+
+
+class FakeDiscovery:
+    def __init__(self, error: OSError) -> None:
+        self.error = error
+        self.VerifiedDevices: dict[str, object] = {}
+        self.calls: list[int] = []
+
+    def DiscoverDevices(self, timeout: int) -> None:
+        self.calls.append(timeout)
+        raise self.error
+
+
+def test_initial_discovery_enodev_keeps_configured_devices_available(
+    monkeypatch, caplog
+):
+    discovery = FakeDiscovery(OSError(errno.ENODEV, "No such device"))
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
+    )
+    datastore = MagicMock()
+    datastore.list_accounts.return_value = ["account-id"]
+    datastore.list_devices.return_value = ["device-id"]
+    datastore.get_device_info.return_value = SimpleNamespace(
+        ip_address="192.0.2.20", name="Configured speaker"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        devices = Speakers(datastore, Settings()).all_devices()
+
+    assert discovery.calls == [1]
+    assert "disappearing network interface" in caplog.text
+    configured = devices["device-id"]
+    assert configured.name == "Configured speaker"
+    assert configured.online is False
+    assert configured.in_soundcork is True
+    assert configured.st_device is None
+
+
+def test_initial_discovery_propagates_other_os_errors(monkeypatch):
+    discovery = FakeDiscovery(OSError(errno.EACCES, "Permission denied"))
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
+    )
+
+    with pytest.raises(OSError, match="Permission denied"):
+        Speakers(object(), object())

--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import xml.etree.ElementTree as ET
 
@@ -60,7 +61,15 @@ class Speakers:
 
     def __init__(self, datastore: DataStore, settings: Settings) -> None:
         self._st_discovery = SoundTouchDiscovery(areDevicesVerified=True)
-        self._st_discovery.DiscoverDevices(timeout=1)
+        try:
+            self._st_discovery.DiscoverDevices(timeout=1)
+        except OSError as exc:
+            if exc.errno != errno.ENODEV:
+                raise
+            logger.warning(
+                "Initial SoundTouch discovery was interrupted by a disappearing "
+                "network interface; continuing with configured devices"
+            )
         self._datastore = datastore
         self._settings = settings
 


### PR DESCRIPTION
## Summary

- Keep Soundcork startup alive when initial SoundTouch discovery is interrupted by a disappearing network interface.
- Continue serving devices configured in the datastore after `errno.ENODEV`.
- Preserve fail-fast behavior for every other `OSError`.

## Rationale

`Speakers` is constructed while the application module is imported. If Zeroconf tries to join a multicast group while an interface is being removed, `SoundTouchDiscovery.DiscoverDevices()` can raise `OSError: [Errno 19] No such device`; without a guard, that exception prevents every Gunicorn worker from starting even though Soundcork can still serve devices already present in its datastore.

This occurred on a running installation during a host update while network interfaces were being reconstructed. Initial network discovery is useful but should not make configured devices unavailable for this specific transient condition.

## Implementation Details

- Catch only `OSError` with `errno.ENODEV` around the initial `DiscoverDevices(timeout=1)` call.
- Log a warning and retain the existing discovery object.
- Re-raise all other operating-system errors unchanged.
- Add regression coverage proving that a configured datastore device remains available and offline after `ENODEV`, and that an unrelated error such as `EACCES` still aborts initialization.

## Tests / Validation

- `pytest -q`: 31 passed.
- `black --target-version py312 --check .`
- `isort --check-only .`
- `mypy .`
- `git diff --check`
- Deployed the equivalent production change to the nspawn-based installation that had failed during a host update. Soundcork started its Gunicorn master and two workers, `/bmx/registry/v1/services` returned HTTP 200, and the same processes and endpoint remained healthy for more than 27 hours at follow-up. The complete host-update race was not repeated.

## Compatibility and Risk

The exception handling is deliberately limited to `ENODEV`, the error observed when the interface disappeared. Configuration, permission, and other network errors remain visible and continue to fail startup. Datastore devices remain available after an interrupted discovery pass, but devices missed by that pass require a restart with working discovery before they can be rediscovered and reported online.

## Non-Goals / Follow-Ups

- This PR does not add generic discovery retries or change later runtime discovery behavior.
- This PR does not change deployment launchers, service managers, or host network configuration.

## Checklist

- [x] Documentation reviewed; no user-facing configuration or workflow changed.
- [x] Fixup commits are squashed away.
- [x] Unit tests added.
- [x] Manual validation and its limits are documented above.
- [x] No migration, dependency, or deadline concerns are known.

## LLM Usage

🤖 Codex authored all production and test code in this pull request and drafted the pull request description under my direction. I reviewed the diff and the pull request description before submitting.
