### PR TITLE
Resolve configured miniapp speakers by stored IP

### DIFF
--- a/soundcork/miniapp.py
+++ b/soundcork/miniapp.py
@@ -35,6 +35,7 @@ class NowPlaying:
     volume_actual: int
     volume_target: int
     is_muted: bool
+    soundcork_managed: bool = False
 
     def is_volume_changing(self) -> bool:
         """Target and Actual values will only be different while volume is changing."""
@@ -211,18 +212,18 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
 
             for device_id in my_combined_devices.keys():
                 try:
+                    cd = my_combined_devices[device_id]
                     if stopped and device_id == selected_device_id:
                         np = NowPlaying("", "", "", 0, 0, False)
-                    else:
+                    elif cd.online or device_id == selected_device_id:
                         np = await _get_now_playing(device_id)
+                    else:
+                        np = NowPlaying("", "", "", 0, 0, False)
                     online = "offline"
-                    cd = my_combined_devices[device_id]
                     device_info = datastore.get_device_info(account_id, device_id)
                     if (
-                        cd.online
-                        and cd.in_soundcork
-                        and (cd.marge_server == "Soundcork")
-                    ):
+                        cd.online and cd.in_soundcork and cd.marge_server == "Soundcork"
+                    ) or (np.soundcork_managed and cd.in_soundcork):
                         online = "online"
                     devices.append(
                         {
@@ -290,19 +291,35 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
         """Get now_playing info for a device"""
         loop = asyncio.get_event_loop()
         try:
-            np = await asyncio.wait_for(
+            playback_state = await asyncio.wait_for(
                 loop.run_in_executor(
                     None,
-                    lambda: speakers.get_now_playing_status(device_id=device_id),
+                    lambda: speakers.get_playback_state(device_id=device_id),
                 ),
                 timeout=NOW_PLAYING_TIMEOUT,
             )
         except asyncio.TimeoutError:
             logger.warning(f"Timeout getting now playing status for {device_id}")
             return NowPlaying("[Unknown]", "", "", 0, 0, False)
+        except Exception as exc:
+            logger.warning(
+                "Error getting now playing status for %s: %s", device_id, exc
+            )
+            return NowPlaying("[Unknown]", "", "", 0, 0, False)
 
-        if np:
-            volume = speakers.get_volume(device_id)
+        if playback_state:
+            np = playback_state.now_playing
+            volume = playback_state.volume
+            if not np:
+                return NowPlaying(
+                    "",
+                    "",
+                    "",
+                    volume.Actual if volume else 0,
+                    volume.Target if volume else 0,
+                    volume.IsMuted if volume else False,
+                    playback_state.soundcork_managed,
+                )
             return NowPlaying(
                 f"{np.StationName or np.ContentItem.Name}",
                 np.ContainerArtUrl or "",
@@ -310,6 +327,7 @@ def get_miniapp_router(datastore: DataStore, speakers: Speakers):
                 volume.Actual if volume else 0,
                 volume.Target if volume else 0,
                 volume.IsMuted if volume else False,
+                playback_state.soundcork_managed,
             )
         else:
             return NowPlaying("", "", "", 0, 0, False)

--- a/soundcork/tests/test_miniapp.py
+++ b/soundcork/tests/test_miniapp.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from soundcork.miniapp import get_miniapp_router
 from soundcork.model import Preset
+from soundcork.ui.speakers import PlaybackState
 
 ACCOUNT_ID = "8208423"
 DEVICE_ID = "device-1"
@@ -51,23 +52,38 @@ class FakeDatastore:
 
 
 class FakeSpeakers:
-    def __init__(self, play_result: bool = True) -> None:
+    def __init__(
+        self,
+        play_result: bool = True,
+        playback_state: PlaybackState | None = None,
+        online: bool = True,
+        marge_server: str = "Soundcork",
+    ) -> None:
         self.play_result = play_result
+        self.playback_state = playback_state
+        self.online = online
+        self.marge_server = marge_server
         self.play_calls: list[tuple[str, str]] = []
+        self.playback_calls: list[str] = []
 
     def all_devices(self):
         return {
             DEVICE_ID: SimpleNamespace(
                 account=ACCOUNT_ID,
-                online=True,
+                online=self.online,
                 in_soundcork=True,
-                marge_server="Soundcork",
+                marge_server=self.marge_server,
             )
         }
 
     def play_content_item(self, device_id: str, content_item_id: str) -> bool:
         self.play_calls.append((device_id, content_item_id))
         return self.play_result
+
+    def get_playback_state(self, device_id: str):
+        assert device_id == DEVICE_ID
+        self.playback_calls.append(device_id)
+        return self.playback_state
 
 
 def make_client(monkeypatch, speakers: FakeSpeakers | None = None):
@@ -99,3 +115,104 @@ def test_dashboard_decodes_display_cookies(monkeypatch):
 
     assert response.status_code == 200
     assert "Účet ložnice" in response.text
+
+
+def configured_playback_state(soundcork_managed: bool = True) -> PlaybackState:
+    now_playing = SimpleNamespace(
+        StationName="Rádio Dechovka",
+        ContentItem=SimpleNamespace(Name="Rádio Dechovka"),
+        ContainerArtUrl="",
+        PlayStatus="PLAY_STATE",
+    )
+    volume = SimpleNamespace(Actual=23, Target=23, IsMuted=False)
+    return PlaybackState(
+        now_playing=now_playing,
+        volume=volume,
+        soundcork_managed=soundcork_managed,
+    )
+
+
+def test_dashboard_resolves_selected_configured_device(monkeypatch):
+    speakers = FakeSpeakers(
+        playback_state=configured_playback_state(),
+        online=False,
+        marge_server="Unknown",
+    )
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert speakers.playback_calls == [DEVICE_ID]
+    assert "Now Playing on ložnice" in response.text
+    assert "Rádio Dechovka" in response.text
+    assert 'class="device-card online"' in response.text
+
+
+def test_dashboard_does_not_probe_unselected_configured_device(monkeypatch):
+    speakers = FakeSpeakers(online=False, marge_server="Unknown")
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+
+    response = client.get(
+        "/miniapp/dashboard",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert speakers.playback_calls == []
+    assert 'class="device-card offline"' in response.text
+
+
+def test_dashboard_keeps_failed_selected_fallback_offline(monkeypatch):
+    speakers = FakeSpeakers(online=False, marge_server="Unknown")
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert speakers.playback_calls == [DEVICE_ID]
+    assert "ložnice" in response.text
+    assert 'class="device-card offline"' in response.text
+
+
+def test_dashboard_keeps_non_soundcork_device_offline(monkeypatch):
+    speakers = FakeSpeakers(
+        playback_state=configured_playback_state(soundcork_managed=False),
+        online=False,
+        marge_server="Unknown",
+    )
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert speakers.playback_calls == [DEVICE_ID]
+    assert "Rádio Dechovka" in response.text
+    assert 'class="device-card offline"' in response.text
+
+
+def test_dashboard_keeps_discovered_bose_device_offline(monkeypatch):
+    speakers = FakeSpeakers(
+        playback_state=configured_playback_state(soundcork_managed=False),
+        online=True,
+        marge_server="Bose",
+    )
+    client, _speakers = make_client(monkeypatch, speakers=speakers)
+
+    response = client.get(
+        f"/miniapp/dashboard?selected_device_id={DEVICE_ID}",
+        headers={"Cookie": f"soundcork_account_id={ACCOUNT_ID}"},
+    )
+
+    assert response.status_code == 200
+    assert speakers.playback_calls == [DEVICE_ID]
+    assert 'class="device-card offline"' in response.text

--- a/soundcork/tests/test_speakers.py
+++ b/soundcork/tests/test_speakers.py
@@ -4,38 +4,84 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from bosesoundtouchapi.soundtouchclient import SoundTouchDevice  # type: ignore
 
 from soundcork.config import Settings
-from soundcork.ui.speakers import Speakers
+from soundcork.ui.speakers import PlaybackState, Speakers
+
+DEVICE_ID = "AABBCCDDEEFF"
+OTHER_DEVICE_ID = "001122334455"
 
 
 class FakeDiscovery:
-    def __init__(self, error: OSError) -> None:
+    def __init__(self, error: OSError | None = None) -> None:
         self.error = error
         self.VerifiedDevices: dict[str, object] = {}
         self.calls: list[int] = []
 
     def DiscoverDevices(self, timeout: int) -> None:
         self.calls.append(timeout)
-        raise self.error
+        if self.error:
+            raise self.error
+
+
+def configured_datastore(device_id: str = DEVICE_ID, ip_address: str = "192.0.2.20"):
+    datastore = MagicMock()
+    datastore.list_accounts.return_value = ["account-id"]
+    datastore.list_devices.return_value = [device_id]
+    datastore.get_device_info.return_value = SimpleNamespace(
+        ip_address=ip_address, name="Configured speaker"
+    )
+    return datastore
+
+
+def configured_soundtouch_device(
+    device_id: str = DEVICE_ID, streaming_url: str | None = None
+):
+    return SimpleNamespace(
+        DeviceId=device_id,
+        Host="192.0.2.20",
+        DeviceName="Configured speaker",
+        StreamingAccountUUID="account-id",
+        StreamingUrl=streaming_url or f"{Settings().base_url}/marge",
+    )
+
+
+def make_speakers(monkeypatch, datastore=None, discovery=None):
+    discovery = discovery or FakeDiscovery()
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
+    )
+    return Speakers(datastore or configured_datastore(), Settings()), discovery
+
+
+def install_successful_client(
+    monkeypatch, st_device=None, now_playing=None, volume=None
+):
+    st_device = st_device or configured_soundtouch_device()
+    device_constructor = MagicMock(return_value=st_device)
+    client = MagicMock()
+    client.GetNowPlayingStatus.return_value = now_playing or object()
+    client.GetVolume.return_value = volume or SimpleNamespace(
+        Actual=23, Target=23, IsMuted=False
+    )
+    client_constructor = MagicMock(return_value=client)
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchDevice", device_constructor)
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchClient", client_constructor)
+    return st_device, device_constructor, client, client_constructor
 
 
 def test_initial_discovery_enodev_keeps_configured_devices_available(
     monkeypatch, caplog
 ):
     discovery = FakeDiscovery(OSError(errno.ENODEV, "No such device"))
-    monkeypatch.setattr(
-        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
-    )
-    datastore = MagicMock()
-    datastore.list_accounts.return_value = ["account-id"]
-    datastore.list_devices.return_value = ["device-id"]
-    datastore.get_device_info.return_value = SimpleNamespace(
-        ip_address="192.0.2.20", name="Configured speaker"
-    )
+    datastore = configured_datastore(device_id="device-id")
 
     with caplog.at_level(logging.WARNING):
-        devices = Speakers(datastore, Settings()).all_devices()
+        speakers, _discovery = make_speakers(
+            monkeypatch, datastore=datastore, discovery=discovery
+        )
+        devices = speakers.all_devices()
 
     assert discovery.calls == [1]
     assert "disappearing network interface" in caplog.text
@@ -54,3 +100,184 @@ def test_initial_discovery_propagates_other_os_errors(monkeypatch):
 
     with pytest.raises(OSError, match="Permission denied"):
         Speakers(object(), object())
+
+
+def test_control_resolves_configured_device_by_ip_without_caching_it(monkeypatch):
+    speakers, _discovery = make_speakers(monkeypatch)
+    st_device, device_constructor, client, client_constructor = (
+        install_successful_client(monkeypatch)
+    )
+
+    state = speakers.get_playback_state(DEVICE_ID)
+
+    assert state == PlaybackState(
+        now_playing=client.GetNowPlayingStatus.return_value,
+        volume=client.GetVolume.return_value,
+        soundcork_managed=True,
+    )
+    call = device_constructor.call_args
+    manager = call.kwargs["proxyManager"]
+    assert call.kwargs["host"] == "192.0.2.20"
+    assert call.kwargs["connectTimeout"] == 1
+    client_constructor.assert_called_once_with(st_device, manager=manager)
+    timeout = manager.connection_pool_kw["timeout"]
+    retries = manager.connection_pool_kw["retries"]
+    assert timeout.connect_timeout == 1.0
+    assert timeout.read_timeout == 2.0
+    assert retries.total == 0
+
+    configured = speakers.all_devices()[DEVICE_ID]
+    assert configured.online is False
+    assert configured.st_device is None
+
+
+def test_control_keeps_discovered_device_behavior(monkeypatch):
+    st_device = MagicMock(spec=SoundTouchDevice)
+    st_device.DeviceId = DEVICE_ID
+    st_device.Host = "192.0.2.20"
+    st_device.DeviceName = "Discovered speaker"
+    st_device.StreamingAccountUUID = "account-id"
+    st_device.StreamingUrl = f"{Settings().base_url}/marge"
+    discovery = FakeDiscovery()
+    discovery.VerifiedDevices = {"192.0.2.20:8090": st_device}
+    datastore = MagicMock()
+    datastore.list_accounts.return_value = []
+    speakers, _discovery = make_speakers(
+        monkeypatch, datastore=datastore, discovery=discovery
+    )
+    fallback_constructor = MagicMock()
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchDevice", fallback_constructor)
+    client = MagicMock()
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchClient", MagicMock(return_value=client)
+    )
+
+    assert speakers.get_playback_state(DEVICE_ID) is not None
+    fallback_constructor.assert_not_called()
+
+
+def test_control_rejects_configured_ip_for_a_different_device(monkeypatch, caplog):
+    speakers, _discovery = make_speakers(monkeypatch)
+    wrong_device = configured_soundtouch_device(OTHER_DEVICE_ID)
+    client_constructor = MagicMock()
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDevice", MagicMock(return_value=wrong_device)
+    )
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchClient", client_constructor)
+
+    with caplog.at_level(logging.WARNING):
+        assert speakers.get_playback_state(DEVICE_ID) is None
+
+    assert f"belongs to device {OTHER_DEVICE_ID}" in caplog.text
+    client_constructor.assert_not_called()
+    assert speakers.all_devices()[DEVICE_ID].online is False
+
+
+def test_control_keeps_unreachable_configured_device_offline(monkeypatch, caplog):
+    speakers, _discovery = make_speakers(monkeypatch)
+    client_constructor = MagicMock()
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDevice",
+        MagicMock(side_effect=TimeoutError("speaker did not answer")),
+    )
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchClient", client_constructor)
+
+    with caplog.at_level(logging.INFO):
+        assert speakers.get_playback_state(DEVICE_ID) is None
+
+    assert "is not reachable through REST" in caplog.text
+    client_constructor.assert_not_called()
+    assert speakers.all_devices()[DEVICE_ID].online is False
+
+
+@pytest.mark.parametrize(
+    ("device_id", "configured_ip"),
+    [
+        ("not-a-device-id", "192.0.2.20"),
+        (DEVICE_ID, "not-an-ip"),
+        (DEVICE_ID, "127.0.0.1"),
+        (DEVICE_ID, "0.0.0.0"),
+        (DEVICE_ID, "224.0.0.1"),
+        (DEVICE_ID, "169.254.169.254"),
+        (DEVICE_ID, "240.0.0.1"),
+        (DEVICE_ID, "255.255.255.255"),
+        (DEVICE_ID, "2001:db8::20"),
+    ],
+)
+def test_control_rejects_invalid_identity_or_address(
+    monkeypatch, device_id, configured_ip
+):
+    datastore = configured_datastore(device_id=device_id, ip_address=configured_ip)
+    speakers, _discovery = make_speakers(monkeypatch, datastore=datastore)
+    constructor = MagicMock()
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchDevice", constructor)
+
+    assert speakers.get_playback_state(device_id) is None
+    constructor.assert_not_called()
+
+
+def test_control_does_not_probe_unknown_configured_device(monkeypatch):
+    datastore = MagicMock()
+    datastore.list_accounts.return_value = []
+    speakers, _discovery = make_speakers(monkeypatch, datastore=datastore)
+    constructor = MagicMock()
+    monkeypatch.setattr("soundcork.ui.speakers.SoundTouchDevice", constructor)
+
+    assert speakers.get_playback_state(DEVICE_ID) is None
+    constructor.assert_not_called()
+
+
+def test_control_discards_resolution_when_configured_ip_changes(monkeypatch):
+    datastore = configured_datastore()
+    addresses = iter(["192.0.2.20", "192.0.2.21"])
+    datastore.get_device_info.side_effect = lambda *_args: SimpleNamespace(
+        ip_address=next(addresses), name="Configured speaker"
+    )
+    speakers, _discovery = make_speakers(monkeypatch, datastore=datastore)
+    st_device, device_constructor, _client, client_constructor = (
+        install_successful_client(monkeypatch)
+    )
+
+    assert speakers.get_playback_state(DEVICE_ID) is None
+    assert device_constructor.call_count == 1
+    client_constructor.assert_not_called()
+
+
+@pytest.mark.parametrize("operation", ["play", "stop"])
+def test_mutation_timeout_is_not_retried(monkeypatch, caplog, operation):
+    datastore = configured_datastore()
+    datastore.get_content_item.return_value = SimpleNamespace(
+        name="Rádio Dechovka",
+        source="LOCAL_INTERNET_RADIO",
+        type="stationurl",
+        location="http://example.com/dechovka.mp3",
+        source_account="",
+        is_presetable=True,
+    )
+    speakers, _discovery = make_speakers(monkeypatch, datastore=datastore)
+    _st_device, device_constructor, client, _client_constructor = (
+        install_successful_client(monkeypatch)
+    )
+    mutation = client.PlayContentItem if operation == "play" else client.MediaStop
+    mutation.side_effect = TimeoutError("response was lost")
+
+    with caplog.at_level(logging.ERROR):
+        if operation == "play":
+            result = speakers.play_content_item(DEVICE_ID, "5")
+        else:
+            result = speakers.stop_playback(DEVICE_ID)
+
+    assert result is False
+    mutation.assert_called_once()
+    assert device_constructor.call_count == 1
+    assert "outcome may be uncertain" in caplog.text
+
+
+def test_control_closes_request_local_http_manager(monkeypatch):
+    speakers, _discovery = make_speakers(monkeypatch)
+    install_successful_client(monkeypatch)
+    http_manager = MagicMock()
+    monkeypatch.setattr(speakers, "_http_manager", lambda: http_manager)
+
+    assert speakers.get_playback_state(DEVICE_ID) is not None
+    http_manager.clear.assert_called_once_with()

--- a/soundcork/tests/test_speakers.py
+++ b/soundcork/tests/test_speakers.py
@@ -1,0 +1,56 @@
+import errno
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from soundcork.config import Settings
+from soundcork.ui.speakers import Speakers
+
+
+class FakeDiscovery:
+    def __init__(self, error: OSError) -> None:
+        self.error = error
+        self.VerifiedDevices: dict[str, object] = {}
+        self.calls: list[int] = []
+
+    def DiscoverDevices(self, timeout: int) -> None:
+        self.calls.append(timeout)
+        raise self.error
+
+
+def test_initial_discovery_enodev_keeps_configured_devices_available(
+    monkeypatch, caplog
+):
+    discovery = FakeDiscovery(OSError(errno.ENODEV, "No such device"))
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
+    )
+    datastore = MagicMock()
+    datastore.list_accounts.return_value = ["account-id"]
+    datastore.list_devices.return_value = ["device-id"]
+    datastore.get_device_info.return_value = SimpleNamespace(
+        ip_address="192.0.2.20", name="Configured speaker"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        devices = Speakers(datastore, Settings()).all_devices()
+
+    assert discovery.calls == [1]
+    assert "disappearing network interface" in caplog.text
+    configured = devices["device-id"]
+    assert configured.name == "Configured speaker"
+    assert configured.online is False
+    assert configured.in_soundcork is True
+    assert configured.st_device is None
+
+
+def test_initial_discovery_propagates_other_os_errors(monkeypatch):
+    discovery = FakeDiscovery(OSError(errno.EACCES, "Permission denied"))
+    monkeypatch.setattr(
+        "soundcork.ui.speakers.SoundTouchDiscovery", lambda **_kwargs: discovery
+    )
+
+    with pytest.raises(OSError, match="Permission denied"):
+        Speakers(object(), object())

--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import xml.etree.ElementTree as ET
 
@@ -60,7 +61,15 @@ class Speakers:
 
     def __init__(self, datastore: DataStore, settings: Settings) -> None:
         self._st_discovery = SoundTouchDiscovery(areDevicesVerified=True)
-        self._st_discovery.DiscoverDevices(timeout=1)
+        try:
+            self._st_discovery.DiscoverDevices(timeout=1)
+        except OSError as exc:
+            if exc.errno != errno.ENODEV:
+                raise
+            logger.warning(
+                "Initial SoundTouch discovery was interrupted by a disappearing "
+                "network interface; continuing with configured devices"
+            )
         self._datastore = datastore
         self._settings = settings
 

--- a/soundcork/ui/speakers.py
+++ b/soundcork/ui/speakers.py
@@ -1,6 +1,11 @@
 import errno
+import ipaddress
 import logging
+import re
 import xml.etree.ElementTree as ET
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
 
 from bosesoundtouchapi.models import NowPlayingStatus, Volume  # type: ignore
 from bosesoundtouchapi.soundtouchclient import (  # type: ignore
@@ -11,12 +16,26 @@ from bosesoundtouchapi.soundtouchclient import (  # type: ignore
 )
 from bosesoundtouchapi.soundtouchdiscovery import SoundTouchDiscovery  # type: ignore
 from pydantic import BaseModel
+from urllib3 import PoolManager, Retry, Timeout
 
 from soundcork.config import Settings
 from soundcork.datastore import DataStore
 from soundcork.model import ContentItem
 
 logger = logging.getLogger(__name__)
+
+SPEAKER_CONNECT_TIMEOUT = 1.0
+SPEAKER_READ_TIMEOUT = 2.0
+SOUNDTOUCH_DEVICE_ID_PATTERN = re.compile(r"^[0-9A-Fa-f]{12}$")
+
+
+@dataclass(frozen=True)
+class PlaybackState:
+    """Current playback state returned by one verified device connection."""
+
+    now_playing: NowPlayingStatus | None
+    volume: Volume | None
+    soundcork_managed: bool
 
 
 class CombinedDevice(BaseModel):
@@ -88,6 +107,13 @@ class Speakers:
         logger.debug(f"Getting device by id: {ip_port}")
         return self._st_discovery.VerifiedDevices.get(ip_port)
 
+    def _marge_server(self, streaming_url: str) -> str:
+        if streaming_url == "https://streaming.bose.com":
+            return "Bose"
+        if streaming_url == f"{self._settings.base_url}/marge":
+            return "Soundcork"
+        return f"Unknown ({streaming_url})"
+
     def all_devices(self) -> dict[str, CombinedDevice]:
         """
         Returns a combination of all devices seen on the network and
@@ -144,14 +170,135 @@ class Speakers:
                 )
                 combined_devices[id] = new_cd
                 sc_device = new_cd
-            if st_device.StreamingUrl == "https://streaming.bose.com":
-                sc_device.marge_server = "Bose"
-            elif st_device.StreamingUrl == f"{self._settings.base_url}/marge":
-                sc_device.marge_server = "Soundcork"
-            else:
-                sc_device.marge_server = f"Unknown ({st_device.StreamingUrl})"
+            sc_device.marge_server = self._marge_server(st_device.StreamingUrl)
 
         return combined_devices
+
+    @staticmethod
+    def _http_manager() -> PoolManager:
+        """Create a request-local HTTP manager with fully bounded I/O."""
+        return PoolManager(
+            headers={"User-Agent": "BoseSoundTouchApi/1.0.0"},
+            timeout=Timeout(
+                connect=SPEAKER_CONNECT_TIMEOUT,
+                read=SPEAKER_READ_TIMEOUT,
+            ),
+            retries=Retry(total=0, connect=0, read=0, redirect=0),
+            num_pools=2,
+            maxsize=2,
+            block=True,
+        )
+
+    def _device_for_control(
+        self, device_id: str
+    ) -> tuple[CombinedDevice | None, PoolManager | None]:
+        """Resolve a live device, using its configured IP as a verified fallback."""
+        combined_device = self.all_devices().get(device_id)
+        if not combined_device or combined_device.st_device:
+            return combined_device, self._http_manager() if combined_device else None
+
+        if not combined_device.in_soundcork or not combined_device.ip:
+            return combined_device, None
+        if not SOUNDTOUCH_DEVICE_ID_PATTERN.fullmatch(device_id):
+            logger.warning("Refusing invalid SoundTouch device ID %s", device_id)
+            return None, None
+
+        try:
+            configured_ip = ipaddress.ip_address(combined_device.ip)
+        except ValueError:
+            logger.warning(
+                "Refusing invalid configured address %s for device %s",
+                combined_device.ip,
+                device_id,
+            )
+            return None, None
+
+        if (
+            not isinstance(configured_ip, ipaddress.IPv4Address)
+            or configured_ip.is_loopback
+            or configured_ip.is_unspecified
+            or configured_ip.is_multicast
+            or configured_ip.is_link_local
+            or configured_ip.is_reserved
+        ):
+            logger.warning(
+                "Refusing unsafe configured address %s for device %s",
+                combined_device.ip,
+                device_id,
+            )
+            return None, None
+
+        expected_account = combined_device.account
+        expected_ip = str(configured_ip)
+        manager = self._http_manager()
+
+        try:
+            st_device = SoundTouchDevice(
+                host=expected_ip,
+                connectTimeout=int(SPEAKER_CONNECT_TIMEOUT),
+                proxyManager=manager,
+            )
+        except Exception as exc:
+            manager.clear()
+            logger.info(
+                "Configured device %s at %s is not reachable through REST: %s",
+                device_id,
+                expected_ip,
+                exc,
+            )
+            return None, None
+
+        try:
+            actual_device_id = str(st_device.DeviceId)
+            if actual_device_id.upper() != device_id.upper():
+                manager.clear()
+                logger.warning(
+                    "Configured address %s for device %s belongs to device %s",
+                    expected_ip,
+                    device_id,
+                    actual_device_id,
+                )
+                return None, None
+
+            current_device = self.all_devices().get(device_id)
+            if (
+                not current_device
+                or not current_device.in_soundcork
+                or current_device.account != expected_account
+                or current_device.ip != expected_ip
+            ):
+                manager.clear()
+                logger.info(
+                    "Configured location changed while resolving device %s; "
+                    "discarding %s",
+                    device_id,
+                    expected_ip,
+                )
+                return None, None
+
+            current_device.st_device = st_device
+            current_device.online = True
+            current_device.marge_server = self._marge_server(st_device.StreamingUrl)
+            return current_device, manager
+        except Exception:
+            manager.clear()
+            raise
+
+    @contextmanager
+    def _client_for_control(
+        self, device_id: str
+    ) -> Iterator[tuple[CombinedDevice | None, SoundTouchClient | None]]:
+        combined_device, manager = self._device_for_control(device_id)
+        if not combined_device or not combined_device.st_device or not manager:
+            yield combined_device, None
+            return
+        try:
+            yield combined_device, SoundTouchClient(
+                combined_device.st_device,
+                manager=manager,
+            )
+        finally:
+            manager.clear()
 
     def _content_item_to_soundtouchclient(self, ci: ContentItem) -> BCContentItem:
         """Maps our ContentItem to a SoundTouchClient ContentItem."""
@@ -174,32 +321,37 @@ class Speakers:
         Returns:
             True if successful, False otherwise
         """
-        cd = self.all_devices().get(device_id)
-        if not cd or not cd.st_device:
-            logger.error(f"Device {device_id} not found or not online")
-            return False
+        with self._client_for_control(device_id) as (cd, client):
+            if not cd or not client:
+                logger.error(f"Device {device_id} not found or not online")
+                return False
 
-        if not cd.account:
-            logger.error(f"Device {device_id} not associated with an account")
-            return False
+            if not cd.account:
+                logger.error(f"Device {device_id} not associated with an account")
+                return False
 
-        content_item = self._datastore.get_content_item(
-            account=cd.account,
-            device_id=cd.id,
-            ci_id=content_item_id,
-        )
-        if not content_item:
-            logger.error(f"{content_item_id} is not a defined ContentItem")
-            return False
+            content_item = self._datastore.get_content_item(
+                account=cd.account,
+                device_id=cd.id,
+                ci_id=content_item_id,
+            )
+            if not content_item:
+                logger.error(f"{content_item_id} is not a defined ContentItem")
+                return False
 
-        logger.info(
-            f"Attempting playback of content item {content_item_id} on device {device_id}"
-        )
-        bose_content_item = self._content_item_to_soundtouchclient(content_item)
-        client = SoundTouchClient(cd.st_device)
-        client.PlayContentItem(bose_content_item)
-
-        return True
+            logger.info(
+                f"Attempting playback of content item {content_item_id} on device {device_id}"
+            )
+            bose_content_item = self._content_item_to_soundtouchclient(content_item)
+            try:
+                client.PlayContentItem(bose_content_item)
+                return True
+            except Exception:
+                logger.exception(
+                    "Playback request for device %s failed; its outcome may be uncertain",
+                    device_id,
+                )
+                return False
 
     def stop_playback(self, device_id: str) -> bool:
         """Stop playback on a specific device.
@@ -210,19 +362,22 @@ class Speakers:
         Returns:
             True if successful, False otherwise
         """
-        cd = self.all_devices().get(device_id)
-        if not cd or not cd.st_device:
-            logger.error(f"Device {device_id} not found or not online")
-            return False
+        with self._client_for_control(device_id) as (cd, client):
+            if not cd or not client:
+                logger.error(f"Device {device_id} not found or not online")
+                return False
 
-        client = SoundTouchClient(cd.st_device)
-        try:
-            client.MediaStop()
-            logger.info(f"Stopped playback on device {device_id}")
-            return True
-        except Exception as e:
-            logger.error(f"Error stopping playback on device {device_id}: {e}")
-            return False
+            try:
+                client.MediaStop()
+                logger.info(f"Stopped playback on device {device_id}")
+                return True
+            except Exception as e:
+                logger.error(
+                    "Stop request for device %s failed; its outcome may be uncertain: %s",
+                    device_id,
+                    e,
+                )
+                return False
 
     def get_volume(self, device_id: str, refresh: bool = False) -> Volume | None:
         """Get the volume of a specific speaker device
@@ -334,3 +489,22 @@ class Speakers:
 
         client = SoundTouchClient(cd.st_device)
         return client.GetNowPlayingStatus()
+
+    def get_playback_state(self, device_id: str) -> PlaybackState | None:
+        """Read playback and volume through one verified, bounded client."""
+        with self._client_for_control(device_id) as (cd, client):
+            if not cd or not client:
+                logger.error(f"Device {device_id} not found or not online")
+                return None
+
+            now_playing = client.GetNowPlayingStatus()
+            try:
+                volume = client.GetVolume(refresh=True)
+            except Exception as exc:
+                logger.warning("Error getting volume for %s: %s", device_id, exc)
+                volume = None
+            return PlaybackState(
+                now_playing=now_playing,
+                volume=volume,
+                soundcork_managed=cd.marge_server == "Soundcork",
+            )


### PR DESCRIPTION
Depends on #363 and is intended to be reviewed and merged after it.

## Summary

- Let miniapp playback, stop, and status requests reach a configured speaker by its stored IPv4 address when it was absent from the initial SoundTouch discovery snapshot.
- Verify that the endpoint reports the requested Bose device ID before using it.
- Keep fallback connections request-local, bounded, and uncached.

## Why

SoundCork currently keeps the one-time discovery result created at process startup. A speaker can therefore remain present in the datastore and visible in the miniapp while playback controls and now-playing status reject it as offline. This is especially visible for routed speakers and after the transient discovery failure handled by #363.

The datastore already records the speaker address from its SoundCork requests, so it provides a useful fallback when discovery did not see that speaker.

## Implementation

- Accept only configured 12-hex SoundTouch IDs and literal IPv4 addresses; reject loopback, unspecified, multicast, link-local, reserved, malformed, and IPv6 addresses.
- Use a request-local `urllib3.PoolManager` with a one-second connect timeout, two-second read timeout, and retries disabled.
- Fetch the live device metadata, compare its device ID with the configured ID, and re-read the datastore before use so a concurrent account or address change discards the result.
- Do not add the resolved device to discovery state or cache it between requests.
- Read now-playing and volume through one verified client.
- Probe an undiscovered configured device only when it is selected in the miniapp. Failed probes keep its card visible and offline.
- Preserve the existing `marge_server == "Soundcork"` condition for enabling a device card and preserve the library's normal playback delay.
- Never retry play or stop after an uncertain timeout.

## Validation

- `pytest -q` (`54 passed`)
- `black --check --target-version py312 .`
- `isort --check-only .`
- `mypy .`
- `git diff --check`
- Read-only live check against a routed SoundTouch speaker that was configured in the datastore but absent from startup discovery: current station, playback state, volume, and SoundCork Marge ownership were all read successfully. No playback or volume state was changed.

## Compatibility and risk

Discovered speakers keep the normal device path. The fallback performs bounded HTTP requests only to the configured speaker address and validates the returned identity before reading status or issuing a requested command. There is no data migration, persistent cache, background probing, or deployment-specific logic.

## Out of scope

- Periodic or event-driven discovery refresh
- Automatically learning or changing stored speaker addresses
- Applying the fallback to account, language, name, or other admin operations
- IPv6 speaker endpoints
